### PR TITLE
fix: harden activities page fetch handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Backend API
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cyclingmetrics
+PORT=4000
+UPLOAD_DIR=./uploads
+AUTH_ENABLED=false
+NEXTAUTH_SECRET=please-change-me
+DEMO_USER_EMAIL=demo@cyclingmetrics.dev
+DEMO_USER_PASSWORD=demo
+
+# Frontend
+NEXT_PUBLIC_API_URL=http://localhost:4000/api
+NEXT_INTERNAL_API_URL=http://backend:4000/api
+NEXT_PUBLIC_AUTH_ENABLED=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.pnpm-store
+.env
+.env.local
+/uploads
+.next
+coverage
+.DS_Store
+prisma/dev.db

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+registry=https://registry.npmjs.org/
+proxy=http://proxy:8080
+https-proxy=http://proxy:8080
+@types:registry=https://registry.npmjs.org/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,177 @@
-# CyclingCustomMetricsOnline
+# Cycling Custom Metrics
+
+Cycling Custom Metrics is a full-stack TypeScript application that ingests Garmin `.FIT` files, normalizes second-by-second activity samples, computes extensible cycling metrics, and renders the results in a modern Next.js dashboard. The first metric shipped is the **Heart Rate to Cadence Scaling Ratio (HCSR)** which highlights cadence efficiency and fatigue trends over the ride.
+
+## Features
+
+- **Node.js + Express API** with Prisma ORM on PostgreSQL and a metric registry for pluggable analytics modules.
+- **Garmin FIT ingestion** using `fit-file-parser` with resampling to 1 Hz, forward filling of small gaps, and sample sanitation.
+- **Extensible metric engine** – add a single file under `apps/backend/src/metrics` to define new metrics, compute logic, and tests.
+- **Next.js 14 App Router UI** styled with TailwindCSS and shadcn/ui components. Includes upload flow, activity list, detail dashboard with HCSR chart, and registry browser.
+- **Optional authentication** powered by NextAuth credentials provider, disabled by default for local development.
+- **Vitest test suite** covering FIT parsing normalization, HCSR computations, registry wiring, and an API happy-path smoke test.
+- **Docker Compose** for local production-style deployment (Postgres + API + Web) and GitHub Actions CI running lint, typecheck, and tests.
+
+## Project Structure
+
+```
+apps/
+  backend/        # Express API, Prisma schema, metrics engine, Vitest tests
+  web/            # Next.js frontend, Tailwind/shadcn components
+.github/workflows # CI pipeline
+``` 
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- pnpm 8+
+- PostgreSQL 15+ (or use Docker Compose)
+
+### Installation
+
+```bash
+pnpm install
+```
+
+### Environment
+
+Copy the example environment and adjust as needed:
+
+```bash
+cp .env.example .env
+```
+
+Key variables:
+
+- `DATABASE_URL` – PostgreSQL connection string used by Prisma.
+- `UPLOAD_DIR` – directory where raw FIT uploads are preserved.
+- `AUTH_ENABLED` / `NEXT_PUBLIC_AUTH_ENABLED` – toggle authentication.
+- `NEXT_PUBLIC_API_URL` – frontend-to-backend base URL (`http://localhost:4000/api` in dev).
+- `NEXT_INTERNAL_API_URL` – internal API URL for server-side Next.js fetching (e.g. `http://backend:4000/api` in Docker).
+- `NEXTAUTH_SECRET`, `DEMO_USER_EMAIL`, `DEMO_USER_PASSWORD` – NextAuth credentials (optional).
+
+### Database
+
+Push the Prisma schema to your Postgres instance and seed metric definitions:
+
+```bash
+pnpm db:push
+pnpm seed
+```
+
+### Development
+
+Run frontend and backend concurrently:
+
+```bash
+pnpm dev
+```
+
+- Backend API: http://localhost:4000
+- Frontend UI: http://localhost:3000
+
+Upload a `.fit` file on the landing page, then navigate to Activities → Activity detail → “Recompute metrics” to generate the HCSR chart.
+
+### Quality Gates
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+Vitest uses in-memory Prisma mocks and fixtures so no database is required during tests.
+
+### Docker Compose
+
+Build and run the entire stack (Postgres + API + Web) with:
+
+```bash
+docker compose up --build
+```
+
+Services:
+
+- API available at http://localhost:4000
+- Web UI at http://localhost:3000
+- Persistent volumes for Postgres data and uploaded FIT files.
+
+### Deployment Guidance
+
+- **Frontend (Next.js)** – deploy on Vercel. Set environment variables (`NEXT_PUBLIC_API_URL`, `NEXT_INTERNAL_API_URL`, `NEXT_PUBLIC_AUTH_ENABLED`, `NEXTAUTH_SECRET`, etc.) pointing to the API host. Build command: `pnpm install --frozen-lockfile && pnpm --filter web build` with output command `pnpm --filter web start`.
+- **Backend (Express)** – deploy on Render, Fly.io, or any Node-compatible host using `apps/backend/Dockerfile`. Provide `DATABASE_URL`, `PORT`, `UPLOAD_DIR`, `AUTH_ENABLED`, and `NEXTAUTH_SECRET`. Run migrations via `pnpm --filter backend db:push` or Prisma migrations prior to launch.
+- **PostgreSQL** – provision a managed instance (Render, Fly.io, Supabase, etc.) and update `DATABASE_URL` accordingly.
+
+## Metric Architecture
+
+Metrics live under `apps/backend/src/metrics`:
+
+- Each metric exports a `definition` (key, name, version, description, units, config) and a `compute` function that receives `MetricSample[]` plus activity context.
+- Register metrics in `registry.ts`. The registry powers seeding (`prisma/seed.ts`) and exposes definitions to the frontend.
+- `runMetrics(activityId, metricKeys?)` orchestrates loading samples, executing metric modules, and upserting `MetricResult` rows.
+- Adding a new metric requires creating a file alongside `hcsr.ts`, exporting it from the registry, and writing a Vitest suite.
+
+### HCSR (Heart Rate to Cadence Scaling Ratio)
+
+Implementation details (`apps/backend/src/metrics/hcsr.ts`):
+
+1. Filter samples with cadence ≥ 20 rpm and valid heart rate, bin into 10 rpm buckets.
+2. Require ≥ 60 seconds per bucket; compute median HR and IQR.
+3. Apply Theil–Sen regression (falling back to OLS) over bucket medians for slope/intercept.
+4. Compare linear vs. piecewise fits for nonlinearity delta; compute R² diagnostics.
+5. Split ride halves to detect fatigue-related slope drift.
+6. Persist summary metrics and per-bucket series for visualization.
+
+## Data Model Notes
+
+- `ActivitySample` stores one row per second with indexes on `(activityId)` and `(activityId, t)`. This keeps queries simple for metrics that scan contiguous time ranges and avoids decoding large JSON payloads at query time. The trade-off is a larger table footprint, but it enables Postgres to stream rows efficiently and lets future metrics push heavy aggregations into SQL if desired.
+- `MetricDefinition`/`MetricResult` separate metadata (name, version, config) from per-activity outputs so metric implementations can evolve independently of stored results. Results store both `summary` JSON (scalars) and optional `series` JSON for charting.
+
+## API Overview
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/api/upload` | Multipart upload of `.fit` file → activity creation |
+| `POST` | `/api/activities/:id/compute` | Compute metrics (defaults to registry) |
+| `GET`  | `/api/activities` | Paginated activity list |
+| `GET`  | `/api/activities/:id` | Activity metadata + metric summaries |
+| `GET`  | `/api/activities/:id/metrics/:metricKey` | Metric result detail (summary + series) |
+| `DELETE` | `/api/activities/:id` | Delete activity and associated data |
+
+All endpoints are user-agnostic by default; enable auth to scope to authenticated users.
+
+## Adding Metrics
+
+1. Create `apps/backend/src/metrics/<metricKey>.ts` exporting `{ definition, compute }`.
+2. Append the metric to the registry in `registry.ts`.
+3. Write Vitest coverage under `apps/backend/tests`.
+4. Run `pnpm seed` to sync `MetricDefinition` rows.
+
+## Testing Fixtures
+
+- FIT ingestion tests mock `fit-file-parser` to validate normalization logic.
+- HCSR tests use synthetic cadence/HR samples to assert slope and fit quality.
+- API smoke test mocks ingestion and executes upload → compute → fetch flow against the Express app.
+
+## Scripts Summary
+
+| Command | Description |
+| ------- | ----------- |
+| `pnpm dev` | Run backend & frontend in watch mode |
+| `pnpm db:push` | Push Prisma schema to the configured Postgres |
+| `pnpm seed` | Seed metric definitions from the registry |
+| `pnpm lint` | ESLint (backend & frontend) |
+| `pnpm typecheck` | TypeScript checks across packages |
+| `pnpm test` | Run Vitest suites |
+
+## Extending & Contributing
+
+- To add authentication providers (GitHub, Google, etc.), configure NextAuth in `apps/web/app/api/auth/[...nextauth]/route.ts`.
+- For additional metrics, leverage the sample utilities in `apps/backend/src/utils/statistics.ts` (median, quantiles, Theil–Sen).
+- The frontend consumes the API via `apps/web/lib/api.ts`. Prefer updating this layer when adding endpoints.
+
+## License
+
+MIT © 2024 Cycling Custom Metrics maintainers.

--- a/apps/backend/.eslintrc.cjs
+++ b/apps/backend/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  root: true,
+  env: {
+    es2021: true,
+    node: true,
+  },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:import/recommended',
+    'plugin:n/recommended',
+    'plugin:promise/recommended',
+    'prettier',
+  ],
+  rules: {
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+      },
+    ],
+    'n/no-missing-import': 'off',
+    'n/no-unsupported-features/es-syntax': 'off',
+  },
+};

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN npm install -g pnpm
+
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY apps/backend/package.json apps/backend/package.json
+
+RUN pnpm install --frozen-lockfile --filter backend...
+
+COPY apps/backend apps/backend
+
+RUN pnpm --filter backend prisma generate
+RUN pnpm --filter backend build
+
+ENV NODE_ENV=production
+ENV PORT=4000
+
+CMD ["pnpm", "--filter", "backend", "start"]

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "backend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "start": "node dist/index.js",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "db:push": "prisma db push",
+    "db:migrate": "prisma migrate deploy",
+    "seed": "prisma db seed"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.11.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "express-async-handler": "^1.2.0",
+    "fit-file-parser": "^1.9.1",
+    "multer": "^1.4.5-lts.1",
+    "pino": "^9.0.0",
+    "pino-pretty": "^10.3.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/multer": "^1.4.7",
+    "@types/node": "^20.11.30",
+    "@types/supertest": "^2.0.16",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-promise": "^6.1.1",
+    "prettier": "^3.2.5",
+    "prisma": "^5.11.0",
+    "supertest": "^6.3.4",
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
+    "tslib": "^2.6.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  }
+}

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,0 +1,71 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        String     @id @default(cuid())
+  email     String?    @unique
+  provider  String?
+  createdAt DateTime   @default(now())
+  activities Activity[]
+}
+
+model Activity {
+  id            String           @id @default(cuid())
+  userId        String?
+  user          User?            @relation(fields: [userId], references: [id])
+  source        String
+  startTime     DateTime
+  durationSec   Int
+  sampleRateHz  Float?
+  createdAt     DateTime         @default(now())
+  samples       ActivitySample[]
+  metrics       MetricResult[]
+}
+
+model ActivitySample {
+  id         BigInt   @id @default(autoincrement())
+  activityId String
+  activity   Activity @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  t          Int
+  heartRate  Int?
+  cadence    Int?
+  power      Int?
+  speed      Float?
+  elevation  Float?
+
+  @@index([activityId])
+  @@index([activityId, t])
+}
+
+model MetricDefinition {
+  id            String          @id @default(cuid())
+  key           String          @unique
+  name          String
+  version       Int             @default(1)
+  description   String
+  units         String?
+  computeConfig Json?
+  createdAt     DateTime        @default(now())
+  results       MetricResult[]
+}
+
+model MetricResult {
+  id                  String           @id @default(cuid())
+  activityId          String
+  activity            Activity         @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  metricDefinitionId  String
+  metricDefinition    MetricDefinition @relation(fields: [metricDefinitionId], references: [id], onDelete: Cascade)
+  summary             Json
+  series              Json?
+  computedAt          DateTime         @default(now())
+
+  @@index([activityId])
+  @@index([metricDefinitionId, activityId])
+  @@unique([activityId, metricDefinitionId])
+}

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,0 +1,39 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '../src/prisma.js';
+import { metricRegistry } from '../src/metrics/registry.js';
+
+async function main() {
+  for (const module of Object.values(metricRegistry)) {
+    const computeConfig = module.definition.computeConfig ?? Prisma.JsonNull;
+    await prisma.metricDefinition.upsert({
+      where: { key: module.definition.key },
+      update: {
+        name: module.definition.name,
+        description: module.definition.description,
+        version: module.definition.version,
+        units: module.definition.units ?? null,
+        computeConfig,
+      },
+      create: {
+        key: module.definition.key,
+        name: module.definition.name,
+        description: module.definition.description,
+        version: module.definition.version,
+        units: module.definition.units ?? null,
+        computeConfig,
+      },
+    });
+  }
+
+  console.log('Seeded metric definitions');
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,0 +1,30 @@
+import cors from 'cors';
+import express from 'express';
+
+import { env } from './env.js';
+import { errorHandler, notFound } from './middleware/errorHandler.js';
+import { apiRouter } from './routes/index.js';
+
+export function createApp() {
+  const app = express();
+
+  app.use(
+    cors({
+      origin: env.FRONTEND_URL ?? true,
+      credentials: true,
+    }),
+  );
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.use('/api', apiRouter);
+
+  app.use(notFound);
+  app.use(errorHandler);
+
+  return app;
+}

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z
+    .string()
+    .optional()
+    .transform((val) => (val ? Number.parseInt(val, 10) : 4000))
+    .pipe(z.number().int().min(0)),
+  DATABASE_URL: z.string(),
+  AUTH_ENABLED: z
+    .string()
+    .optional()
+    .transform((val) => (val ? val.toLowerCase() === 'true' : false)),
+  NEXTAUTH_SECRET: z.string().optional(),
+  UPLOAD_DIR: z.string().default('./uploads'),
+  FRONTEND_URL: z.string().optional(),
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  console.error('Invalid environment variables', parsed.error.flatten().fieldErrors);
+  throw new Error('Invalid environment variables');
+}
+
+export const env = parsed.data;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { env } from './env.js';
+import { createApp } from './app.js';
+import { logger } from './logger.js';
+
+const app = createApp();
+
+const uploadDir = path.resolve(env.UPLOAD_DIR);
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+app.listen(env.PORT, () => {
+  logger.info(`API listening on port ${env.PORT}`);
+});

--- a/apps/backend/src/logger.ts
+++ b/apps/backend/src/logger.ts
@@ -1,0 +1,17 @@
+import pino from 'pino';
+
+import { env } from './env.js';
+
+export const logger = pino({
+  level: env.NODE_ENV === 'production' ? 'info' : 'debug',
+  transport:
+    env.NODE_ENV === 'production'
+      ? undefined
+      : {
+          target: 'pino-pretty',
+          options: {
+            translateTime: 'SYS:standard',
+            ignore: 'pid,hostname',
+          },
+        },
+});

--- a/apps/backend/src/metrics/hcsr.ts
+++ b/apps/backend/src/metrics/hcsr.ts
@@ -1,0 +1,240 @@
+import type { MetricModule } from './types.js';
+import {
+  computeR2,
+  linearRegression,
+  median,
+  quantile,
+  theilSenSlope,
+  type XYPoint,
+} from '../utils/statistics.js';
+import type { MetricSample } from './types.js';
+
+const MIN_CADENCE = 20;
+const BUCKET_SIZE = 10;
+const REQUIRED_SECONDS_PER_BUCKET = 60;
+
+interface BucketStats {
+  cadenceStart: number;
+  cadenceEnd: number;
+  cadenceMid: number;
+  seconds: number;
+  medianHR: number;
+  hr25: number;
+  hr75: number;
+}
+
+function bucketKey(cadence: number): number {
+  if (cadence >= 130) {
+    return 130;
+  }
+  return Math.floor(cadence / BUCKET_SIZE) * BUCKET_SIZE;
+}
+
+function cadenceMidpoint(bucketStart: number): number {
+  if (bucketStart >= 130) {
+    return 135;
+  }
+  return bucketStart + BUCKET_SIZE / 2;
+}
+
+function buildBuckets(samples: MetricSample[]) {
+  const buckets = new Map<
+    number,
+    { heartRates: number[]; seconds: number }
+  >();
+  let validSeconds = 0;
+
+  for (const sample of samples) {
+    if (sample.heartRate == null || sample.cadence == null) {
+      continue;
+    }
+    if (sample.cadence < MIN_CADENCE) {
+      continue;
+    }
+    validSeconds += 1;
+    const key = bucketKey(sample.cadence);
+    const bucket = buckets.get(key) ?? { heartRates: [], seconds: 0 };
+    bucket.heartRates.push(sample.heartRate);
+    bucket.seconds += 1;
+    buckets.set(key, bucket);
+  }
+
+  const bucketStats: BucketStats[] = [];
+  for (const [key, value] of buckets) {
+    if (value.seconds < REQUIRED_SECONDS_PER_BUCKET) {
+      continue;
+    }
+    bucketStats.push({
+      cadenceStart: key,
+      cadenceEnd: key >= 130 ? 999 : key + BUCKET_SIZE - 1,
+      cadenceMid: cadenceMidpoint(key),
+      seconds: value.seconds,
+      medianHR: median(value.heartRates),
+      hr25: quantile(value.heartRates, 0.25),
+      hr75: quantile(value.heartRates, 0.75),
+    });
+  }
+
+  bucketStats.sort((a, b) => a.cadenceMid - b.cadenceMid);
+
+  return { bucketStats, validSeconds };
+}
+
+function toPoints(bucketStats: BucketStats[]): XYPoint[] {
+  return bucketStats.map((bucket) => ({
+    x: bucket.cadenceMid,
+    y: bucket.medianHR,
+  }));
+}
+
+function computePiecewiseR2(points: XYPoint[], globalSsTot: number) {
+  if (points.length < 4) {
+    return null;
+  }
+  const midIndex = Math.floor(points.length / 2);
+  const firstHalf = points.slice(0, midIndex);
+  const secondHalf = points.slice(midIndex);
+  if (firstHalf.length < 2 || secondHalf.length < 2) {
+    return null;
+  }
+  const firstFit = linearRegression(firstHalf);
+  const secondFit = linearRegression(secondHalf);
+
+  let ssResPiecewise = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const point = points[i];
+    const prediction =
+      i < firstHalf.length
+        ? firstFit.slope * point.x + firstFit.intercept
+        : secondFit.slope * point.x + secondFit.intercept;
+    ssResPiecewise += (point.y - prediction) ** 2;
+  }
+  const piecewiseR2 = globalSsTot === 0 ? 1 : 1 - ssResPiecewise / globalSsTot;
+  return piecewiseR2;
+}
+
+function computeSlopeForHalf(samples: MetricSample[], maxTime: number | null) {
+  const filtered = samples.filter((sample) => {
+    if (sample.heartRate == null || sample.cadence == null) {
+      return false;
+    }
+    if (sample.cadence < MIN_CADENCE) {
+      return false;
+    }
+    if (maxTime == null) {
+      return true;
+    }
+    return sample.t <= maxTime;
+  });
+
+  if (filtered.length < 2) {
+    return null;
+  }
+
+  const points = filtered.map((sample) => ({
+    x: sample.cadence as number,
+    y: sample.heartRate as number,
+  }));
+  return linearRegression(points).slope;
+}
+
+function computeSlopeForSecondHalf(samples: MetricSample[], minTime: number) {
+  const filtered = samples.filter((sample) => {
+    if (sample.heartRate == null || sample.cadence == null) {
+      return false;
+    }
+    if (sample.cadence < MIN_CADENCE) {
+      return false;
+    }
+    return sample.t > minTime;
+  });
+
+  if (filtered.length < 2) {
+    return null;
+  }
+
+  const points = filtered.map((sample) => ({
+    x: sample.cadence as number,
+    y: sample.heartRate as number,
+  }));
+  return linearRegression(points).slope;
+}
+
+export const hcsrMetric: MetricModule = {
+  definition: {
+    key: 'hcsr',
+    name: 'HR-to-Cadence Scaling Ratio',
+    version: 1,
+    description:
+      'Quantifies how heart rate scales with cadence across cadence buckets with fatigue diagnostics.',
+    units: 'bpm/rpm',
+    computeConfig: {
+      cadenceBucketSize: BUCKET_SIZE,
+      minCadence: MIN_CADENCE,
+      requiredSecondsPerBucket: REQUIRED_SECONDS_PER_BUCKET,
+    },
+  },
+  compute: (samples, context) => {
+    const { bucketStats, validSeconds } = buildBuckets(samples);
+    const points = toPoints(bucketStats);
+
+    let slope: number | null = null;
+    let intercept: number | null = null;
+    let r2: number | null = null;
+    let nonlinearityDelta: number | null = null;
+    let piecewiseR2: number | null = null;
+
+    if (points.length >= 2) {
+      const robustFit = theilSenSlope(points);
+      if (robustFit) {
+        slope = Number.parseFloat(robustFit.slope.toFixed(4));
+        intercept = Number.parseFloat(robustFit.intercept.toFixed(2));
+      } else {
+        const ols = linearRegression(points);
+        slope = Number.parseFloat(ols.slope.toFixed(4));
+        intercept = Number.parseFloat(ols.intercept.toFixed(2));
+      }
+      if (slope !== null && intercept !== null) {
+        const { r2: computedR2, ssTot } = computeR2(points, slope, intercept);
+        r2 = Number.parseFloat(computedR2.toFixed(4));
+        const piecewise = computePiecewiseR2(points, ssTot);
+        if (piecewise != null) {
+          piecewiseR2 = Number.parseFloat(piecewise.toFixed(4));
+          nonlinearityDelta = Number.parseFloat(
+            (piecewiseR2 - (r2 ?? 0)).toFixed(4),
+          );
+        }
+      }
+    }
+
+    const halfDuration = Math.floor(context.activity.durationSec / 2);
+    const firstHalfSlope = computeSlopeForHalf(samples, halfDuration);
+    const secondHalfSlope = computeSlopeForSecondHalf(samples, halfDuration);
+    const deltaSlopeHalf =
+      firstHalfSlope != null && secondHalfSlope != null
+        ? Number.parseFloat((secondHalfSlope - firstHalfSlope).toFixed(4))
+        : null;
+
+    const series = bucketStats.map((bucket) => ({
+      cadenceMid: bucket.cadenceMid,
+      medianHR: bucket.medianHR,
+      seconds: bucket.seconds,
+      hr25: bucket.hr25,
+      hr75: bucket.hr75,
+    }));
+
+    return {
+      summary: {
+        slope_bpm_per_rpm: slope,
+        intercept_bpm: intercept,
+        r2,
+        nonlinearity_delta: nonlinearityDelta,
+        half_split_delta_slope: deltaSlopeHalf,
+        valid_seconds: validSeconds,
+        bucket_count: bucketStats.length,
+        piecewise_r2: piecewiseR2,
+      },
+      series,
+    };
+  },
+};

--- a/apps/backend/src/metrics/registry.ts
+++ b/apps/backend/src/metrics/registry.ts
@@ -1,0 +1,18 @@
+import { hcsrMetric } from './hcsr.js';
+import { torqueVariabilityIndexMetric } from './tvi.js';
+import { whrEfficiencyMetric } from './whrEfficiency.js';
+import type { MetricModule } from './types.js';
+
+export const metricRegistry: Record<string, MetricModule> = {
+  [hcsrMetric.definition.key]: hcsrMetric,
+  [torqueVariabilityIndexMetric.definition.key]: torqueVariabilityIndexMetric,
+  [whrEfficiencyMetric.definition.key]: whrEfficiencyMetric,
+};
+
+export function listMetricDefinitions() {
+  return Object.values(metricRegistry).map((module) => module.definition);
+}
+
+export function getMetricModule(key: string): MetricModule | undefined {
+  return metricRegistry[key];
+}

--- a/apps/backend/src/metrics/runner.ts
+++ b/apps/backend/src/metrics/runner.ts
@@ -1,0 +1,118 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '../prisma.js';
+import { logger } from '../logger.js';
+import type { MetricComputationResult, MetricModule, MetricSample } from './types.js';
+import { getMetricModule, metricRegistry } from './registry.js';
+
+function normalizeSeries(series: unknown) {
+  if (series === undefined) {
+    return Prisma.JsonNull;
+  }
+  return series as Prisma.JsonValue;
+}
+
+function normalizeSummary(summary: Record<string, unknown>) {
+  return summary as Prisma.JsonObject;
+}
+
+function selectMetricModules(metricKeys?: string[]): MetricModule[] {
+  const keys = metricKeys ?? Object.keys(metricRegistry);
+  return keys.map((key) => {
+    const module = getMetricModule(key);
+    if (!module) {
+      throw new Error(`Unknown metric key: ${key}`);
+    }
+    return module;
+  });
+}
+
+async function ensureDefinition(module: MetricModule) {
+  const computeConfig = module.definition.computeConfig ?? Prisma.JsonNull;
+  const definition = await prisma.metricDefinition.upsert({
+    where: { key: module.definition.key },
+    update: {
+      name: module.definition.name,
+      description: module.definition.description,
+      version: module.definition.version,
+      units: module.definition.units ?? null,
+      computeConfig,
+    },
+    create: {
+      key: module.definition.key,
+      name: module.definition.name,
+      description: module.definition.description,
+      version: module.definition.version,
+      units: module.definition.units ?? null,
+      computeConfig,
+    },
+  });
+  return definition;
+}
+
+function mapSamples(samples: { t: number; heartRate: number | null; cadence: number | null; power: number | null; speed: number | null; elevation: number | null }[]): MetricSample[] {
+  return samples.map((sample) => ({
+    t: sample.t,
+    heartRate: sample.heartRate,
+    cadence: sample.cadence,
+    power: sample.power,
+    speed: sample.speed,
+    elevation: sample.elevation,
+  }));
+}
+
+export async function runMetrics(activityId: string, metricKeys?: string[]) {
+  const modules = selectMetricModules(metricKeys);
+
+  const activity = await prisma.activity.findUnique({
+    where: { id: activityId },
+  });
+
+  if (!activity) {
+    throw new Error('Activity not found');
+  }
+
+  const samples = await prisma.activitySample.findMany({
+    where: { activityId },
+    orderBy: { t: 'asc' },
+  });
+
+  const metricSamples = mapSamples(samples);
+  const results: Record<string, MetricComputationResult> = {};
+
+  for (const module of modules) {
+    const definition = await ensureDefinition(module);
+    try {
+      const computation = await module.compute(metricSamples, { activity });
+      await prisma.metricResult.upsert({
+        where: {
+          activityId_metricDefinitionId: {
+            activityId,
+            metricDefinitionId: definition.id,
+          },
+        },
+        update: {
+          summary: normalizeSummary(computation.summary),
+          series: normalizeSeries(computation.series ?? null),
+          computedAt: new Date(),
+        },
+        create: {
+          activityId,
+          metricDefinitionId: definition.id,
+          summary: normalizeSummary(computation.summary),
+          series: normalizeSeries(computation.series ?? null),
+        },
+      });
+      results[module.definition.key] = computation;
+    } catch (error) {
+      logger.error({ error, metric: module.definition.key }, 'Metric computation failed');
+      results[module.definition.key] = {
+        summary: {
+          error: (error as Error).message,
+        },
+      };
+    }
+  }
+
+  return results;
+}

--- a/apps/backend/src/metrics/tvi.ts
+++ b/apps/backend/src/metrics/tvi.ts
@@ -1,0 +1,22 @@
+import type { MetricModule } from './types.js';
+
+export const torqueVariabilityIndexMetric: MetricModule = {
+  definition: {
+    key: 'tvi',
+    name: 'Torque Variability Index',
+    version: 1,
+    description:
+      'Estimates on-bike torque smoothness and variability from cadence and power. Placeholder implementation.',
+    units: 'dimensionless',
+    computeConfig: {
+      windowSeconds: 30,
+    },
+  },
+  compute: () => ({
+    summary: {
+      implemented: false,
+      note:
+        'TVI requires high-resolution torque reconstruction and is planned for a future release.',
+    },
+  }),
+};

--- a/apps/backend/src/metrics/types.ts
+++ b/apps/backend/src/metrics/types.ts
@@ -1,0 +1,36 @@
+import type { Activity } from '@prisma/client';
+
+export interface MetricSample {
+  t: number;
+  heartRate: number | null;
+  cadence: number | null;
+  power: number | null;
+  speed: number | null;
+  elevation: number | null;
+}
+
+export interface MetricDefinitionShape {
+  key: string;
+  name: string;
+  version: number;
+  description: string;
+  units?: string;
+  computeConfig?: Record<string, unknown>;
+}
+
+export interface MetricComputationContext {
+  activity: Activity;
+}
+
+export interface MetricComputationResult {
+  summary: Record<string, unknown>;
+  series?: unknown;
+}
+
+export interface MetricModule {
+  definition: MetricDefinitionShape;
+  compute: (
+    samples: MetricSample[],
+    context: MetricComputationContext,
+  ) => Promise<MetricComputationResult> | MetricComputationResult;
+}

--- a/apps/backend/src/metrics/whrEfficiency.ts
+++ b/apps/backend/src/metrics/whrEfficiency.ts
@@ -1,0 +1,22 @@
+import type { MetricModule } from './types.js';
+
+export const whrEfficiencyMetric: MetricModule = {
+  definition: {
+    key: 'whr-efficiency',
+    name: 'Watts/HR Efficiency Curve',
+    version: 1,
+    description:
+      'Profiles aerobic efficiency over time by comparing power-to-heart-rate ratios. Placeholder implementation.',
+    units: 'W/bpm',
+    computeConfig: {
+      percentiles: [0.25, 0.5, 0.75],
+    },
+  },
+  compute: () => ({
+    summary: {
+      implemented: false,
+      note:
+        'W/HR efficiency analysis will chart aerobic decoupling once power streams are available.',
+    },
+  }),
+};

--- a/apps/backend/src/middleware/errorHandler.ts
+++ b/apps/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,26 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import { logger } from '../logger.js';
+
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  const status = (err as { status?: number }).status ?? 500;
+  const message =
+    (err as { message?: string }).message ?? 'Unexpected server error occurred.';
+
+  if (status >= 500) {
+    logger.error({ err }, 'Unhandled error');
+  } else {
+    logger.warn({ err }, 'Request error');
+  }
+
+  res.status(status).json({ error: message });
+}
+
+export function notFound(_req: Request, res: Response): void {
+  res.status(404).json({ error: 'Route not found' });
+}

--- a/apps/backend/src/parsers/fit.ts
+++ b/apps/backend/src/parsers/fit.ts
@@ -1,0 +1,148 @@
+import fs from 'node:fs/promises';
+
+import FitParser from 'fit-file-parser';
+
+import type { NormalizedActivity, NormalizedActivitySample } from '../types.js';
+
+const parser = new FitParser({
+  force: true,
+  elapsedRecordField: true,
+  speedUnit: 'm/s',
+  lengthUnit: 'm',
+});
+
+type FitRecord = {
+  timestamp?: Date | string;
+  heart_rate?: number;
+  cadence?: number;
+  power?: number;
+  speed?: number;
+  enhanced_altitude?: number;
+  altitude?: number;
+};
+
+function sanitizeInt(value: unknown, min: number, max: number): number | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+  if (value < min || value > max) {
+    return null;
+  }
+  return Math.round(value);
+}
+
+function sanitizeFloat(value: unknown, min: number, max: number): number | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+  if (value < min || value > max) {
+    return null;
+  }
+  return Number.parseFloat(value.toFixed(3));
+}
+
+function cloneSample(sample: NormalizedActivitySample, t: number): NormalizedActivitySample {
+  return {
+    t,
+    heartRate: sample.heartRate ?? null,
+    cadence: sample.cadence ?? null,
+    power: sample.power ?? null,
+    speed: sample.speed ?? null,
+    elevation: sample.elevation ?? null,
+  };
+}
+
+export async function parseFitFile(filePath: string): Promise<NormalizedActivity> {
+  const fileBuffer = await fs.readFile(filePath);
+
+  const result = await new Promise<{ records?: FitRecord[] }>((resolve, reject) => {
+    parser.parse(fileBuffer, (error: unknown, data: { records?: FitRecord[] }) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(data);
+    });
+  });
+
+  const records = (result.records ?? []).filter((record) => record.timestamp);
+
+  if (records.length === 0) {
+    throw new Error('FIT file has no timestamped records.');
+  }
+
+  const sortedRecords = records.sort((a, b) => {
+    const aTime = new Date(a.timestamp as Date | string).getTime();
+    const bTime = new Date(b.timestamp as Date | string).getTime();
+    return aTime - bTime;
+  });
+
+  const startTime = new Date(sortedRecords[0].timestamp as Date | string);
+  const startMs = startTime.getTime();
+
+  const samplesBySecond = new Map<number, NormalizedActivitySample>();
+
+  for (const record of sortedRecords) {
+    const timestamp = new Date(record.timestamp as Date | string).getTime();
+    const t = Math.max(0, Math.round((timestamp - startMs) / 1000));
+    const heartRate = sanitizeInt(record.heart_rate, 30, 240);
+    const cadence = sanitizeInt(record.cadence, 0, 220);
+    const power = sanitizeInt(record.power, 0, 2500);
+    const speed = sanitizeFloat(record.speed, 0, 30);
+    const elevation = sanitizeFloat(
+      record.enhanced_altitude ?? record.altitude,
+      -500,
+      9000,
+    );
+
+    samplesBySecond.set(t, {
+      t,
+      heartRate,
+      cadence,
+      power,
+      speed,
+      elevation,
+    });
+  }
+
+  const sortedTimes = Array.from(samplesBySecond.keys()).sort((a, b) => a - b);
+  const lastTime = sortedTimes[sortedTimes.length - 1] ?? 0;
+
+  const samples: NormalizedActivitySample[] = [];
+  let pointer = 0;
+  let previousSample: NormalizedActivitySample | null = null;
+
+  for (let t = 0; t <= lastTime; t += 1) {
+    if (sortedTimes[pointer] === t) {
+      const sample = samplesBySecond.get(t)!;
+      samples.push(sample);
+      previousSample = sample;
+      pointer += 1;
+    } else {
+      const nextKnown = sortedTimes[pointer] ?? Number.POSITIVE_INFINITY;
+      if (previousSample && nextKnown - t <= 3) {
+        samples.push(cloneSample(previousSample, t));
+      } else {
+        samples.push({
+          t,
+          heartRate: null,
+          cadence: null,
+          power: null,
+          speed: null,
+          elevation: null,
+        });
+      }
+    }
+  }
+
+  const durationSec = lastTime;
+  const sampleRateHz = samples.length > 0 && durationSec > 0 ? 1 : null;
+
+  return {
+    source: 'garmin-fit',
+    startTime,
+    durationSec,
+    sampleRateHz,
+    samples,
+  };
+}

--- a/apps/backend/src/prisma.ts
+++ b/apps/backend/src/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+import { env } from './env.js';
+import { logger } from './logger.js';
+
+export const prisma = new PrismaClient({
+  log: env.NODE_ENV === 'development' ? ['query', 'info', 'warn', 'error'] : ['error'],
+});
+
+process.on('beforeExit', async () => {
+  await prisma.$disconnect();
+  logger.debug('Prisma disconnected');
+});

--- a/apps/backend/src/routes/activities.ts
+++ b/apps/backend/src/routes/activities.ts
@@ -1,0 +1,143 @@
+import type { Prisma } from '@prisma/client';
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
+
+import { prisma } from '../prisma.js';
+import { deleteActivity } from '../services/activityService.js';
+import { runMetrics } from '../metrics/runner.js';
+
+const paginationSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(10),
+});
+
+const computeSchema = z
+  .object({
+    metricKeys: z.array(z.string()).min(1).optional(),
+  })
+  .optional();
+
+type ActivityWithMetrics = Prisma.ActivityGetPayload<{
+  include: {
+    metrics: {
+      include: {
+        metricDefinition: true;
+      };
+    };
+  };
+}>;
+
+function mapActivity(activity: ActivityWithMetrics) {
+  return {
+    id: activity.id,
+    source: activity.source,
+    startTime: activity.startTime,
+    durationSec: activity.durationSec,
+    sampleRateHz: activity.sampleRateHz,
+    createdAt: activity.createdAt,
+    metrics: (activity.metrics ?? []).map((metric: any) => ({
+      key: metric.metricDefinition.key,
+      summary: metric.summary,
+      computedAt: metric.computedAt,
+    })),
+  };
+}
+
+export const activitiesRouter = express.Router();
+
+activitiesRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const params = paginationSchema.parse(req.query);
+    const skip = (params.page - 1) * params.pageSize;
+
+    const [activities, total] = await Promise.all([
+      prisma.activity.findMany({
+        skip,
+        take: params.pageSize,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          metrics: {
+            include: { metricDefinition: true },
+          },
+        },
+      }),
+      prisma.activity.count(),
+    ]);
+
+    res.json({
+      data: activities.map(mapActivity),
+      page: params.page,
+      pageSize: params.pageSize,
+      total,
+    });
+  }),
+);
+
+activitiesRouter.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const activity = await prisma.activity.findUnique({
+      where: { id: req.params.id },
+      include: {
+        metrics: {
+          include: { metricDefinition: true },
+          orderBy: { computedAt: 'desc' },
+        },
+      },
+    });
+
+    if (!activity) {
+      res.status(404).json({ error: 'Activity not found' });
+      return;
+    }
+
+    res.json(mapActivity(activity));
+  }),
+);
+
+activitiesRouter.post(
+  '/:id/compute',
+  asyncHandler(async (req, res) => {
+    const body = computeSchema.parse(req.body);
+    const metricKeys = body?.metricKeys;
+
+    const results = await runMetrics(req.params.id, metricKeys ?? undefined);
+    res.json({ activityId: req.params.id, results });
+  }),
+);
+
+activitiesRouter.get(
+  '/:id/metrics/:metricKey',
+  asyncHandler(async (req, res) => {
+    const metricResult = await prisma.metricResult.findFirst({
+      where: {
+        activityId: req.params.id,
+        metricDefinition: { key: req.params.metricKey },
+      },
+      include: { metricDefinition: true },
+    });
+
+    if (!metricResult) {
+      res.status(404).json({ error: 'Metric result not found' });
+      return;
+    }
+
+    res.json({
+      key: metricResult.metricDefinition.key,
+      definition: metricResult.metricDefinition,
+      summary: metricResult.summary,
+      series: metricResult.series,
+      computedAt: metricResult.computedAt,
+    });
+  }),
+);
+
+activitiesRouter.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    await deleteActivity(req.params.id);
+    res.status(204).send();
+  }),
+);

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+
+import { activitiesRouter } from './activities.js';
+import { metricsRouter } from './metrics.js';
+import { uploadRouter } from './upload.js';
+
+export const apiRouter = express.Router();
+
+apiRouter.use('/upload', uploadRouter);
+apiRouter.use('/activities', activitiesRouter);
+apiRouter.use('/metrics', metricsRouter);

--- a/apps/backend/src/routes/metrics.ts
+++ b/apps/backend/src/routes/metrics.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+import { listMetricDefinitions } from '../metrics/registry.js';
+
+export const metricsRouter = express.Router();
+
+metricsRouter.get('/', (_req, res) => {
+  res.json({ definitions: listMetricDefinitions() });
+});

--- a/apps/backend/src/routes/upload.ts
+++ b/apps/backend/src/routes/upload.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import multer from 'multer';
+
+import { env } from '../env.js';
+import { logger } from '../logger.js';
+import { ingestFitFile } from '../services/ingestService.js';
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, env.UPLOAD_DIR);
+  },
+  filename: (_req, file, cb) => {
+    const safeName = file.originalname.toLowerCase().replace(/[^a-z0-9_.-]+/g, '-');
+    const uniqueName = `${Date.now()}-${safeName}`;
+    cb(null, uniqueName);
+  },
+});
+
+function fitFileFilter(
+  _req: express.Request,
+  file: Express.Multer.File,
+  cb: multer.FileFilterCallback,
+) {
+  if (!file.originalname.toLowerCase().endsWith('.fit')) {
+    cb(new Error('Only .fit files are supported'));
+    return;
+  }
+  cb(null, true);
+}
+
+const upload = multer({ storage, fileFilter: fitFileFilter });
+
+export const uploadRouter = express.Router();
+
+uploadRouter.post(
+  '/',
+  upload.single('file'),
+  asyncHandler(async (req, res) => {
+    const file = req.file;
+    if (!file) {
+      res.status(400).json({ error: 'FIT file is required.' });
+      return;
+    }
+
+    try {
+      const { activity } = await ingestFitFile(file.path);
+      res.status(201).json({ activityId: activity.id });
+    } catch (error) {
+      try {
+        await fs.unlink(file.path);
+      } catch (cleanupError) {
+        logger.warn({ cleanupError }, 'Failed to remove uploaded file after error');
+      }
+      throw error;
+    }
+  }),
+);

--- a/apps/backend/src/services/activityService.ts
+++ b/apps/backend/src/services/activityService.ts
@@ -1,0 +1,72 @@
+import type { Prisma } from '@prisma/client';
+
+import { prisma } from '../prisma.js';
+import type { NormalizedActivity } from '../types.js';
+
+const SAMPLE_INSERT_CHUNK = 5000;
+
+type ActivityCreateInput = Prisma.ActivityCreateInput;
+type ActivitySampleCreateManyInput = Prisma.ActivitySampleCreateManyInput;
+
+function buildActivityData(
+  normalized: NormalizedActivity,
+  userId?: string,
+): ActivityCreateInput {
+  return {
+    source: normalized.source,
+    startTime: normalized.startTime,
+    durationSec: normalized.durationSec,
+    sampleRateHz: normalized.sampleRateHz,
+    user: userId ? { connect: { id: userId } } : undefined,
+  };
+}
+
+function buildSampleRows(
+  activityId: string,
+  normalized: NormalizedActivity,
+): ActivitySampleCreateManyInput[] {
+  return normalized.samples.map((sample) => ({
+    activityId,
+    t: sample.t,
+    heartRate: sample.heartRate ?? null,
+    cadence: sample.cadence ?? null,
+    power: sample.power ?? null,
+    speed: sample.speed ?? null,
+    elevation: sample.elevation ?? null,
+  }));
+}
+
+export async function saveActivity(
+  normalized: NormalizedActivity,
+  userId?: string,
+) {
+  if (normalized.samples.length === 0) {
+    throw new Error('No samples parsed from FIT file.');
+  }
+
+  const activity = await prisma.$transaction(async (tx) => {
+    const created = await tx.activity.create({
+      data: buildActivityData(normalized, userId),
+    });
+
+    const rows = buildSampleRows(created.id, normalized);
+
+    for (let i = 0; i < rows.length; i += SAMPLE_INSERT_CHUNK) {
+      const chunk = rows.slice(i, i + SAMPLE_INSERT_CHUNK);
+      await tx.activitySample.createMany({ data: chunk });
+    }
+
+    return created;
+  });
+
+  return activity;
+}
+
+export async function deleteActivity(activityId: string, userId?: string) {
+  return prisma.activity.delete({
+    where: {
+      id: activityId,
+      ...(userId ? { userId } : {}),
+    },
+  });
+}

--- a/apps/backend/src/services/ingestService.ts
+++ b/apps/backend/src/services/ingestService.ts
@@ -1,0 +1,9 @@
+import { parseFitFile } from '../parsers/fit.js';
+import { saveActivity } from './activityService.js';
+
+export async function ingestFitFile(filePath: string, userId?: string) {
+  const normalized = await parseFitFile(filePath);
+  const activity = await saveActivity(normalized, userId);
+
+  return { activity, normalized };
+}

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -1,0 +1,16 @@
+export interface NormalizedActivitySample {
+  t: number;
+  heartRate?: number | null;
+  cadence?: number | null;
+  power?: number | null;
+  speed?: number | null;
+  elevation?: number | null;
+}
+
+export interface NormalizedActivity {
+  source: string;
+  startTime: Date;
+  durationSec: number;
+  sampleRateHz?: number | null;
+  samples: NormalizedActivitySample[];
+}

--- a/apps/backend/src/utils/statistics.ts
+++ b/apps/backend/src/utils/statistics.ts
@@ -1,0 +1,101 @@
+export interface XYPoint {
+  x: number;
+  y: number;
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error('Cannot compute median of empty array');
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+export function quantile(values: number[], q: number): number {
+  if (values.length === 0) {
+    throw new Error('Cannot compute quantile of empty array');
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = (sorted.length - 1) * q;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+  const weight = index - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+export function linearRegression(points: XYPoint[]) {
+  if (points.length === 0) {
+    throw new Error('Cannot compute regression of empty points');
+  }
+  const n = points.length;
+  const sumX = points.reduce((acc, point) => acc + point.x, 0);
+  const sumY = points.reduce((acc, point) => acc + point.y, 0);
+  const sumXY = points.reduce((acc, point) => acc + point.x * point.y, 0);
+  const sumXX = points.reduce((acc, point) => acc + point.x * point.x, 0);
+
+  const denominator = n * sumXX - sumX * sumX;
+  const slope = denominator === 0 ? 0 : (n * sumXY - sumX * sumY) / denominator;
+  const intercept = n === 0 ? 0 : (sumY - slope * sumX) / n;
+
+  const meanY = sumY / n;
+  let ssTot = 0;
+  let ssRes = 0;
+  for (const point of points) {
+    const predicted = slope * point.x + intercept;
+    ssTot += (point.y - meanY) ** 2;
+    ssRes += (point.y - predicted) ** 2;
+  }
+  const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot;
+
+  return { slope, intercept, r2, ssRes, ssTot };
+}
+
+export function theilSenSlope(points: XYPoint[]): { slope: number; intercept: number } | null {
+  if (points.length < 2) {
+    return null;
+  }
+  const slopes: number[] = [];
+  for (let i = 0; i < points.length; i += 1) {
+    for (let j = i + 1; j < points.length; j += 1) {
+      const dx = points[j].x - points[i].x;
+      if (dx === 0) {
+        continue;
+      }
+      slopes.push((points[j].y - points[i].y) / dx);
+    }
+  }
+
+  if (slopes.length === 0) {
+    return null;
+  }
+
+  const slope = median(slopes);
+  const intercepts = points.map((point) => point.y - slope * point.x);
+  const intercept = median(intercepts);
+
+  return { slope, intercept };
+}
+
+export function computeR2(points: XYPoint[], slope: number, intercept: number) {
+  if (points.length === 0) {
+    return { r2: 0, ssRes: 0, ssTot: 0 };
+  }
+  const meanY =
+    points.reduce((acc, point) => acc + point.y, 0) / points.length;
+  let ssTot = 0;
+  let ssRes = 0;
+  for (const point of points) {
+    const predicted = slope * point.x + intercept;
+    ssTot += (point.y - meanY) ** 2;
+    ssRes += (point.y - predicted) ** 2;
+  }
+  const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot;
+  return { r2, ssRes, ssTot };
+}

--- a/apps/backend/tests/api.e2e.test.ts
+++ b/apps/backend/tests/api.e2e.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createApp } from '../src/app.js';
+import type { NormalizedActivity } from '../src/types.js';
+
+function buildNormalizedActivity(): NormalizedActivity {
+  const samples: NormalizedActivity['samples'] = [];
+  const cadenceBuckets = [
+    { cadence: 60, heartRate: 120 },
+    { cadence: 80, heartRate: 130 },
+    { cadence: 100, heartRate: 140 },
+    { cadence: 120, heartRate: 150 },
+  ];
+  let t = 0;
+  for (const bucket of cadenceBuckets) {
+    for (let i = 0; i < 60; i += 1) {
+      samples.push({
+        t,
+        cadence: bucket.cadence,
+        heartRate: bucket.heartRate + (i % 3),
+        power: null,
+        speed: null,
+        elevation: null,
+      });
+      t += 1;
+    }
+  }
+
+  return {
+    source: 'garmin-fit',
+    startTime: new Date('2024-01-01T00:00:00Z'),
+    durationSec: samples[samples.length - 1]?.t ?? 0,
+    sampleRateHz: 1,
+    samples,
+  };
+}
+
+vi.mock('../src/services/ingestService.js', () => ({
+  ingestFitFile: vi.fn(async () => {
+    const { saveActivity } = await import('../src/services/activityService.js');
+    const normalized = buildNormalizedActivity();
+    const activity = await saveActivity(normalized);
+    return { activity, normalized };
+  }),
+}));
+
+const app = createApp();
+const fixturePath = new URL('./fixtures/mock.fit', import.meta.url).pathname;
+
+describe('Activities API flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ingests, computes metrics, and retrieves results', async () => {
+    const uploadResponse = await request(app)
+      .post('/api/upload')
+      .attach('file', fixturePath);
+
+    expect(uploadResponse.status).toBe(201);
+    const activityId = uploadResponse.body.activityId;
+    expect(activityId).toBeDefined();
+
+    const computeResponse = await request(app)
+      .post(`/api/activities/${activityId}/compute`)
+      .send();
+
+    expect(computeResponse.status).toBe(200);
+    expect(computeResponse.body.results.hcsr).toBeDefined();
+
+    const detailResponse = await request(app).get(`/api/activities/${activityId}`);
+    expect(detailResponse.status).toBe(200);
+    expect(detailResponse.body.metrics.length).toBeGreaterThan(0);
+
+    const metricResponse = await request(app).get(
+      `/api/activities/${activityId}/metrics/hcsr`,
+    );
+    expect(metricResponse.status).toBe(200);
+    expect(metricResponse.body.summary.slope_bpm_per_rpm).toBeGreaterThan(0);
+    expect(Array.isArray(metricResponse.body.series)).toBe(true);
+  });
+});

--- a/apps/backend/tests/fixtures/mock.fit
+++ b/apps/backend/tests/fixtures/mock.fit
@@ -1,0 +1,1 @@
+FAKEFIT

--- a/apps/backend/tests/hcsrMetric.test.ts
+++ b/apps/backend/tests/hcsrMetric.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { hcsrMetric } from '../src/metrics/hcsr.js';
+import type { MetricSample } from '../src/metrics/types.js';
+
+function buildSamples(): MetricSample[] {
+  const samples: MetricSample[] = [];
+  let t = 0;
+  const cadenceBuckets = [
+    { cadence: 60, seconds: 120 },
+    { cadence: 80, seconds: 120 },
+    { cadence: 100, seconds: 120 },
+    { cadence: 120, seconds: 120 },
+  ];
+  const slope = 0.45;
+  for (const bucket of cadenceBuckets) {
+    for (let i = 0; i < bucket.seconds; i += 1) {
+      const noise = ((i % 5) - 2) * 0.1;
+      samples.push({
+        t,
+        cadence: bucket.cadence,
+        heartRate: Math.round(95 + slope * bucket.cadence + noise),
+        power: null,
+        speed: null,
+        elevation: null,
+      });
+      t += 1;
+    }
+  }
+  return samples;
+}
+
+describe('hcsrMetric', () => {
+  it('computes a positive slope when HR increases with cadence', () => {
+    const samples = buildSamples();
+    const activity = {
+      id: 'act_1',
+      userId: null,
+      source: 'garmin-fit',
+      startTime: new Date(),
+      durationSec: samples[samples.length - 1].t,
+      sampleRateHz: 1,
+      createdAt: new Date(),
+    } as const;
+
+    const result = hcsrMetric.compute(samples, { activity });
+
+    expect(result.summary.slope_bpm_per_rpm).toBeDefined();
+    expect(result.summary.slope_bpm_per_rpm).toBeGreaterThan(0.4);
+    expect(result.summary.r2).toBeGreaterThan(0.9);
+    expect(result.summary.bucket_count).toBe(4);
+    expect(Array.isArray(result.series)).toBe(true);
+  });
+});

--- a/apps/backend/tests/parseFitFile.test.ts
+++ b/apps/backend/tests/parseFitFile.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { parseFitFile } from '../src/parsers/fit.js';
+
+let mockRecords: any[] = [];
+
+vi.mock('fit-file-parser', () => {
+  return {
+    default: class FitParser {
+      parse(_buffer: Buffer, callback: (error: unknown, data: any) => void) {
+        callback(null, { records: mockRecords });
+      }
+    },
+  };
+});
+
+const fixturePath = new URL('./fixtures/mock.fit', import.meta.url).pathname;
+
+describe('parseFitFile', () => {
+  beforeEach(() => {
+    const base = new Date('2024-01-01T00:00:00Z');
+    mockRecords = [
+      {
+        timestamp: base,
+        heart_rate: 100,
+        cadence: 80,
+        power: 200,
+        speed: 8,
+        enhanced_altitude: 100,
+      },
+      {
+        timestamp: new Date(base.getTime() + 1000),
+        heart_rate: 102,
+        cadence: 82,
+        power: 210,
+        speed: 8.2,
+        enhanced_altitude: 101,
+      },
+      {
+        timestamp: new Date(base.getTime() + 4000),
+        heart_rate: 108,
+        cadence: 90,
+        power: 230,
+        speed: 8.5,
+        enhanced_altitude: 103,
+      },
+    ];
+  });
+
+  it('normalizes samples to a 1Hz grid with forward fill on small gaps', async () => {
+    const activity = await parseFitFile(fixturePath);
+
+    expect(activity.source).toBe('garmin-fit');
+    expect(activity.samples).toHaveLength(5);
+    expect(activity.samples[0].t).toBe(0);
+    expect(activity.samples[4].t).toBe(4);
+    expect(activity.samples[2].heartRate).toBe(activity.samples[1].heartRate);
+    expect(activity.samples[3].heartRate).toBe(activity.samples[1].heartRate);
+    expect(activity.durationSec).toBe(4);
+  });
+});

--- a/apps/backend/tests/registry.test.ts
+++ b/apps/backend/tests/registry.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { listMetricDefinitions, metricRegistry } from '../src/metrics/registry.js';
+
+describe('metric registry', () => {
+  it('includes hcsr metric and stubs for future metrics', () => {
+    expect(metricRegistry).toHaveProperty('hcsr');
+    expect(metricRegistry).toHaveProperty('tvi');
+    expect(metricRegistry).toHaveProperty('whr-efficiency');
+
+    const definitions = listMetricDefinitions();
+    const keys = definitions.map((definition) => definition.key);
+    expect(keys).toContain('hcsr');
+    expect(keys).toContain('tvi');
+    expect(keys).toContain('whr-efficiency');
+  });
+});

--- a/apps/backend/tests/setup.ts
+++ b/apps/backend/tests/setup.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from 'node:crypto';
+
+import { beforeEach, vi } from 'vitest';
+
+type ActivityRecord = {
+  id: string;
+  source: string;
+  startTime: Date;
+  durationSec: number;
+  sampleRateHz: number | null;
+  createdAt: Date;
+  userId?: string | null;
+};
+
+type ActivitySampleRecord = {
+  activityId: string;
+  t: number;
+  heartRate: number | null;
+  cadence: number | null;
+  power: number | null;
+  speed: number | null;
+  elevation: number | null;
+};
+
+type MetricDefinitionRecord = {
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  version: number;
+  units: string | null;
+  computeConfig: unknown;
+  createdAt: Date;
+};
+
+type MetricResultRecord = {
+  id: string;
+  activityId: string;
+  metricDefinitionId: string;
+  summary: unknown;
+  series: unknown;
+  computedAt: Date;
+};
+
+interface MockDatabase {
+  activities: Map<string, ActivityRecord>;
+  samples: Map<string, ActivitySampleRecord[]>;
+  metricDefinitions: Map<string, MetricDefinitionRecord>;
+  metricResults: Map<string, MetricResultRecord>;
+}
+
+function createMockDatabase(): MockDatabase {
+  return {
+    activities: new Map(),
+    samples: new Map(),
+    metricDefinitions: new Map(),
+    metricResults: new Map(),
+  };
+}
+
+const db = createMockDatabase();
+
+function cloneActivity(activity: ActivityRecord) {
+  return { ...activity };
+}
+
+function attachMetrics(activity: ActivityRecord) {
+  const metrics = Array.from(db.metricResults.values())
+    .filter((metric) => metric.activityId === activity.id)
+    .map((metric) => ({
+      ...metric,
+      metricDefinition: db.metricDefinitions.get(metric.metricDefinitionId)!,
+    }));
+
+  return {
+    ...cloneActivity(activity),
+    metrics,
+  };
+}
+
+const prismaMock = {
+  $transaction: async <T>(fn: (tx: typeof prismaMock) => Promise<T>): Promise<T> => {
+    return fn(prismaMock);
+  },
+  activity: {
+    create: async ({ data }: any) => {
+      const id = data.id ?? randomUUID();
+      const record: ActivityRecord = {
+        id,
+        source: data.source,
+        startTime: data.startTime,
+        durationSec: data.durationSec,
+        sampleRateHz: data.sampleRateHz ?? null,
+        createdAt: data.createdAt ?? new Date(),
+        userId: data.user?.connect?.id ?? null,
+      };
+      db.activities.set(id, record);
+      return cloneActivity(record);
+    },
+    findMany: async ({ skip = 0, take, orderBy, include }: any) => {
+      let activities = Array.from(db.activities.values());
+      if (orderBy?.createdAt === 'desc') {
+        activities.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      }
+      if (orderBy?.createdAt === 'asc') {
+        activities.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      }
+      const slice = activities.slice(skip, take ? skip + take : undefined);
+      if (include?.metrics) {
+        return slice.map((activity) => attachMetrics(activity));
+      }
+      return slice.map((activity) => cloneActivity(activity));
+    },
+    count: async () => db.activities.size,
+    findUnique: async ({ where, include }: any) => {
+      const activity = db.activities.get(where.id);
+      if (!activity) {
+        return null;
+      }
+      if (include?.metrics) {
+        return attachMetrics(activity);
+      }
+      return cloneActivity(activity);
+    },
+    delete: async ({ where }: any) => {
+      const activity = db.activities.get(where.id);
+      if (!activity) {
+        throw new Error('Activity not found');
+      }
+      db.activities.delete(where.id);
+      db.samples.delete(where.id);
+      for (const [key, metric] of db.metricResults.entries()) {
+        if (metric.activityId === where.id) {
+          db.metricResults.delete(key);
+        }
+      }
+      return cloneActivity(activity);
+    },
+  },
+  activitySample: {
+    createMany: async ({ data }: any) => {
+      const entries = Array.isArray(data) ? data : [data];
+      for (const entry of entries) {
+        const list = db.samples.get(entry.activityId) ?? [];
+        list.push({ ...entry });
+        db.samples.set(entry.activityId, list);
+      }
+      return { count: entries.length };
+    },
+    findMany: async ({ where, orderBy }: any) => {
+      const list = db.samples.get(where.activityId) ?? [];
+      if (orderBy?.t === 'asc') {
+        return [...list].sort((a, b) => a.t - b.t);
+      }
+      if (orderBy?.t === 'desc') {
+        return [...list].sort((a, b) => b.t - a.t);
+      }
+      return [...list];
+    },
+  },
+  metricDefinition: {
+    upsert: async ({ where, update, create }: any) => {
+      const existing = Array.from(db.metricDefinitions.values()).find(
+        (definition) => definition.key === where.key,
+      );
+      if (existing) {
+        const updated = {
+          ...existing,
+          ...update,
+        };
+        db.metricDefinitions.set(existing.id, updated);
+        return { ...updated };
+      }
+      const id = randomUUID();
+      const record: MetricDefinitionRecord = {
+        id,
+        key: create.key,
+        name: create.name,
+        description: create.description,
+        version: create.version,
+        units: create.units ?? null,
+        computeConfig: create.computeConfig ?? null,
+        createdAt: new Date(),
+      };
+      db.metricDefinitions.set(id, record);
+      return { ...record };
+    },
+  },
+  metricResult: {
+    upsert: async ({ where, update, create }: any) => {
+      const key = `${where.activityId_metricDefinitionId.activityId}:${where.activityId_metricDefinitionId.metricDefinitionId}`;
+      const existing = db.metricResults.get(key);
+      if (existing) {
+        const updated: MetricResultRecord = {
+          ...existing,
+          summary: update.summary,
+          series: update.series,
+          computedAt: update.computedAt,
+        };
+        db.metricResults.set(key, updated);
+        return { ...updated };
+      }
+      const id = randomUUID();
+      const record: MetricResultRecord = {
+        id,
+        activityId: create.activityId,
+        metricDefinitionId: create.metricDefinitionId,
+        summary: create.summary,
+        series: create.series,
+        computedAt: create.computedAt ?? new Date(),
+      };
+      db.metricResults.set(key, record);
+      return { ...record };
+    },
+    findFirst: async ({ where, include }: any) => {
+      const definition = Array.from(db.metricDefinitions.values()).find(
+        (def) => def.key === where.metricDefinition.key,
+      );
+      if (!definition) {
+        return null;
+      }
+      const result = Array.from(db.metricResults.values()).find(
+        (metric) =>
+          metric.activityId === where.activityId &&
+          metric.metricDefinitionId === definition.id,
+      );
+      if (!result) {
+        return null;
+      }
+      if (include?.metricDefinition) {
+        return { ...result, metricDefinition: { ...definition } };
+      }
+      return { ...result };
+    },
+  },
+};
+
+vi.mock('../src/prisma.js', () => ({ prisma: prismaMock }));
+
+beforeEach(() => {
+  db.activities.clear();
+  db.samples.clear();
+  db.metricDefinitions.clear();
+  db.metricResults.clear();
+});
+
+export { db, prismaMock };

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": false
+  },
+  "exclude": ["tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests", "prisma"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    setupFiles: ['./tests/setup.ts'],
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
+});

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN npm install -g pnpm
+
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY apps/web/package.json apps/web/package.json
+
+RUN pnpm install --frozen-lockfile --filter web...
+
+COPY apps/web apps/web
+
+RUN pnpm --filter web build
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+CMD ["pnpm", "--filter", "web", "start"]

--- a/apps/web/app/activities/[id]/page.tsx
+++ b/apps/web/app/activities/[id]/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from 'next/navigation';
+
+import { ActivityDetailClient } from '../../../components/activity-detail-client';
+import { env } from '../../../lib/env';
+import type { ActivitySummary, MetricResultDetail } from '../../../types/activity';
+
+async function getActivity(id: string): Promise<ActivitySummary> {
+  const response = await fetch(`${env.internalApiUrl}/activities/${id}`, {
+    cache: 'no-store',
+  });
+  if (response.status === 404) {
+    notFound();
+  }
+  if (!response.ok) {
+    throw new Error('Failed to load activity');
+  }
+  return (await response.json()) as ActivitySummary;
+}
+
+async function getHcsrMetric(id: string): Promise<MetricResultDetail | null> {
+  const response = await fetch(`${env.internalApiUrl}/activities/${id}/metrics/hcsr`, {
+    cache: 'no-store',
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error('Failed to load metric result');
+  }
+  return (await response.json()) as MetricResultDetail;
+}
+
+export default async function ActivityDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const activity = await getActivity(params.id);
+  const hcsr = await getHcsrMetric(params.id);
+
+  return <ActivityDetailClient activity={activity} initialHcsr={hcsr} />;
+}

--- a/apps/web/app/activities/page.tsx
+++ b/apps/web/app/activities/page.tsx
@@ -1,0 +1,92 @@
+import Link from 'next/link';
+
+import { fetchActivities } from '../../lib/api';
+import { formatDuration } from '../../lib/utils';
+import type { ActivitySummary } from '../../types/activity';
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
+import { Badge } from '../../components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
+
+export default async function ActivitiesPage() {
+  let activities: ActivitySummary[] = [];
+  let error: string | null = null;
+
+  try {
+    const response = await fetchActivities(1, 50);
+    activities = response.data;
+  } catch (err) {
+    error =
+      err instanceof Error
+        ? err.message
+        : 'Unknown error while fetching activities. Check the API logs for details.';
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Activities</h1>
+        <p className="text-muted-foreground">
+          Recently uploaded FIT rides with computed metric summaries.
+        </p>
+      </div>
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Unable to load activities</AlertTitle>
+          <AlertDescription>
+            {error}. Ensure the backend API is running and the database has been migrated{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">pnpm db:push</code>.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-semibold">Activity history</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Start time</TableHead>
+                  <TableHead>Duration</TableHead>
+                  <TableHead>Metrics</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {activities.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
+                      No activities yet. Upload a FIT file to see your rides here.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  activities.map((activity) => (
+                    <TableRow key={activity.id}>
+                      <TableCell className="font-medium">
+                        {new Date(activity.startTime).toLocaleString()}
+                      </TableCell>
+                      <TableCell>{formatDuration(activity.durationSec)}</TableCell>
+                      <TableCell className="space-x-2">
+                        {activity.metrics.length === 0 ? (
+                          <Badge variant="outline">Pending</Badge>
+                        ) : (
+                          activity.metrics.map((metric) => <Badge key={metric.key}>{metric.key}</Badge>)
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Link className="text-primary underline" href={`/activities/${activity.id}`}>
+                          View
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,45 @@
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+
+import { env } from '../../../../lib/env';
+
+const demoEmail = process.env.DEMO_USER_EMAIL ?? 'demo@cyclingmetrics.dev';
+const demoPassword = process.env.DEMO_USER_PASSWORD ?? 'demo';
+
+const handler = NextAuth({
+  providers: [
+    Credentials({
+      name: 'Demo Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email', value: demoEmail },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!env.authEnabled) {
+          return {
+            id: 'demo-user',
+            email: demoEmail,
+            name: 'Demo Rider',
+          };
+        }
+        if (
+          credentials?.email === demoEmail &&
+          credentials?.password === demoPassword
+        ) {
+          return {
+            id: 'demo-user',
+            email: demoEmail,
+            name: 'Demo Rider',
+          };
+        }
+        return null;
+      },
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+});
+
+export { handler as GET, handler as POST };

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,77 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 210 40% 98%;
+
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 221.2 83.2% 53.3%;
+
+  --radius: 0.75rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 224 71% 4%;
+    --foreground: 213 31% 91%;
+
+    --card: 224 71% 4%;
+    --card-foreground: 213 31% 91%;
+
+    --popover: 224 71% 4%;
+    --popover-foreground: 213 31% 91%;
+
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+
+    --secondary: 222.2 47.4% 11.2%;
+    --secondary-foreground: 210 40% 98%;
+
+    --muted: 223 47% 11%;
+    --muted-foreground: 215 20% 65%;
+
+    --accent: 216 34% 17%;
+    --accent-foreground: 210 40% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 216 34% 17%;
+    --input: 216 34% 17%;
+    --ring: 213 31% 91%;
+  }
+}
+
+body {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-feature-settings: 'rlig' 1, 'calt' 1;
+}
+
+* {
+  border-color: hsl(var(--border));
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+
+import './globals.css';
+import { AuthProvider } from '../components/auth-provider';
+import { SiteHeader } from '../components/site-header';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Cycling Custom Metrics',
+  description:
+    'Upload Garmin FIT files, compute custom cycling analytics, and explore extensible metrics.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <AuthProvider>
+          <div className="flex min-h-screen flex-col bg-background">
+            <SiteHeader />
+            <main className="container mx-auto flex-1 px-4 py-6">{children}</main>
+            <footer className="border-t py-6 text-center text-sm text-muted-foreground">
+              Built for cyclists who love data-driven training.
+            </footer>
+          </div>
+        </AuthProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/metrics/page.tsx
+++ b/apps/web/app/metrics/page.tsx
@@ -1,0 +1,54 @@
+import { env } from '../../lib/env';
+import type { MetricDefinition } from '../../types/activity';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+
+async function getMetricDefinitions(): Promise<MetricDefinition[]> {
+  const response = await fetch(`${env.internalApiUrl}/metrics`, {
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to load metric definitions');
+  }
+  const data = (await response.json()) as { definitions: MetricDefinition[] };
+  return data.definitions;
+}
+
+export default async function MetricsPage() {
+  const definitions = await getMetricDefinitions();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Metric registry</h1>
+        <p className="text-muted-foreground">
+          Each metric is self-contained with a definition, compute function, and Vitest coverage.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {definitions.map((definition) => (
+          <Card key={definition.key}>
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">
+                {definition.name}
+                <span className="ml-2 text-xs text-muted-foreground">v{definition.version}</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <p>{definition.description}</p>
+              {definition.units ? (
+                <p>
+                  <span className="font-medium text-foreground">Units:</span> {definition.units}
+                </p>
+              ) : null}
+              {definition.computeConfig ? (
+                <pre className="rounded-md bg-muted p-3 text-xs">
+                  {JSON.stringify(definition.computeConfig, null, 2)}
+                </pre>
+              ) : null}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,10 @@
+export default function NotFound() {
+  return (
+    <div className="py-24 text-center">
+      <h1 className="text-3xl font-bold">Activity not found</h1>
+      <p className="mt-2 text-muted-foreground">
+        The requested resource could not be located. Try uploading a new ride.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link';
+
+import { LandingUpload } from '../components/landing-upload';
+import { buttonVariants } from '../components/ui/button';
+import { cn } from '../lib/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+
+const features = [
+  {
+    title: 'Parse & Normalize',
+    description: 'Resample FIT data to 1 Hz, clean anomalies, and store every second in Postgres.',
+  },
+  {
+    title: 'Extensible Metrics',
+    description: 'Add new metrics by dropping a single file into the registry with tests and definitions.',
+  },
+  {
+    title: 'Actionable Insights',
+    description:
+      'Visualize the HR-to-Cadence Scaling Ratio with fatigue diagnostics to guide cadence drills.',
+  },
+];
+
+export default function HomePage() {
+  return (
+    <div className="space-y-16">
+      <section className="grid gap-10 lg:grid-cols-2 lg:items-center">
+        <div className="space-y-6">
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+            Cycling Custom Metrics
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Upload Garmin FIT rides, compute novel endurance metrics, and build your own analytics
+            extensions without touching the core ingestion pipeline.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/activities"
+              className={cn(buttonVariants({ variant: 'default' }))}
+            >
+              View activities
+            </Link>
+            <Link
+              href="/metrics"
+              className={cn(buttonVariants({ variant: 'secondary' }))}
+            >
+              Browse metric registry
+            </Link>
+          </div>
+        </div>
+        <LandingUpload />
+      </section>
+      <section className="grid gap-6 md:grid-cols-3">
+        {features.map((feature) => (
+          <Card key={feature.title}>
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">{feature.title}</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              {feature.description}
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/components/activity-detail-client.tsx
+++ b/apps/web/components/activity-detail-client.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Loader2, RefreshCw } from 'lucide-react';
+
+import { computeMetrics, fetchMetricResult } from '../lib/api';
+import type { ActivitySummary, MetricResultDetail } from '../types/activity';
+import { HcsrChart } from './hcsr-chart';
+import { MetricSummaryCard } from './metric-summary-card';
+import { Button } from './ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Alert, AlertDescription, AlertTitle } from './ui/alert';
+
+interface ActivityDetailClientProps {
+  activity: ActivitySummary;
+  initialHcsr?: MetricResultDetail | null;
+}
+
+type HcsrSummary = {
+  slope?: number | null;
+  intercept?: number | null;
+  r2?: number | null;
+  nonlinearity?: number | null;
+  deltaSlope?: number | null;
+  validSeconds?: number | null;
+  bucketCount?: number | null;
+};
+
+type HcsrSeries = Array<{
+  cadenceMid: number;
+  medianHR: number;
+  seconds: number;
+  hr25?: number;
+  hr75?: number;
+}>;
+
+function parseHcsrSummary(metric: MetricResultDetail | null | undefined): HcsrSummary {
+  if (!metric) {
+    return {};
+  }
+  const summary = metric.summary as Record<string, unknown>;
+  return {
+    slope: typeof summary.slope_bpm_per_rpm === 'number' ? summary.slope_bpm_per_rpm : null,
+    intercept: typeof summary.intercept_bpm === 'number' ? summary.intercept_bpm : null,
+    r2: typeof summary.r2 === 'number' ? summary.r2 : null,
+    nonlinearity:
+      typeof summary.nonlinearity_delta === 'number' ? summary.nonlinearity_delta : null,
+    deltaSlope:
+      typeof summary.half_split_delta_slope === 'number'
+        ? summary.half_split_delta_slope
+        : null,
+    validSeconds:
+      typeof summary.valid_seconds === 'number' ? summary.valid_seconds : null,
+    bucketCount: typeof summary.bucket_count === 'number' ? summary.bucket_count : null,
+  };
+}
+
+function parseHcsrSeries(metric: MetricResultDetail | null | undefined): HcsrSeries {
+  if (!metric || !Array.isArray(metric.series)) {
+    return [];
+  }
+  return metric.series.filter((entry): entry is HcsrSeries[number] => {
+    return (
+      typeof entry === 'object' &&
+      entry !== null &&
+      typeof (entry as any).cadenceMid === 'number' &&
+      typeof (entry as any).medianHR === 'number'
+    );
+  });
+}
+
+export function ActivityDetailClient({ activity, initialHcsr }: ActivityDetailClientProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [metric, setMetric] = useState<MetricResultDetail | null | undefined>(initialHcsr);
+
+  const summary = parseHcsrSummary(metric ?? null);
+  const series = parseHcsrSeries(metric ?? null);
+
+  const slopeDisplay = summary.slope != null ? summary.slope.toFixed(3) : '—';
+  const r2Display = summary.r2 != null ? summary.r2.toFixed(3) : '—';
+  const nonlinearityDisplay =
+    summary.nonlinearity != null ? summary.nonlinearity.toFixed(3) : '—';
+
+  const handleRecompute = () => {
+    startTransition(async () => {
+      setError(null);
+      try {
+        await computeMetrics(activity.id, ['hcsr']);
+        const latest = await fetchMetricResult(activity.id, 'hcsr');
+        setMetric(latest);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+        <div>
+          <h1 className="text-3xl font-bold">Ride on {new Date(activity.startTime).toLocaleString()}</h1>
+          <p className="text-muted-foreground">
+            {activity.source} · duration {Math.round(activity.durationSec / 60)} minutes
+          </p>
+        </div>
+        <Button onClick={handleRecompute} disabled={isPending} variant="secondary">
+          {isPending ? (
+            <span className="flex items-center space-x-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Recomputing…</span>
+            </span>
+          ) : (
+            <span className="flex items-center space-x-2">
+              <RefreshCw className="h-4 w-4" />
+              <span>Recompute metrics</span>
+            </span>
+          )}
+        </Button>
+      </div>
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Computation failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      <div className="grid gap-4 md:grid-cols-3">
+        <MetricSummaryCard
+          title="Slope"
+          value={slopeDisplay}
+          units="bpm/rpm"
+          description="Heart rate cost per cadence rpm"
+        />
+        <MetricSummaryCard
+          title="R²"
+          value={r2Display}
+          description="Goodness-of-fit across cadence buckets"
+        />
+        <MetricSummaryCard
+          title="Nonlinearity delta"
+          value={nonlinearityDisplay}
+          description="Piecewise improvement vs linear fit"
+        />
+        <MetricSummaryCard
+          title="Intercept"
+          value={summary.intercept?.toFixed(1)}
+          units="bpm"
+          description="Estimated HR at zero cadence"
+        />
+        <MetricSummaryCard
+          title="Half split Δ slope"
+          value={summary.deltaSlope?.toFixed(3)}
+          description="Fatigue signature between ride halves"
+        />
+        <MetricSummaryCard
+          title="Valid seconds"
+          value={summary.validSeconds ?? '—'}
+          description="Data contributing to the analysis"
+        />
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>HR-to-Cadence Scaling Ratio buckets</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {series.length > 0 ? (
+            <HcsrChart buckets={series} slope={summary.slope ?? null} intercept={summary.intercept ?? null} />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Upload a ride with valid cadence and heart rate data to visualize the scaling ratio.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/auth-provider.tsx
+++ b/apps/web/components/auth-provider.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+import { env } from '../lib/env';
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  if (!env.authEnabled) {
+    return <>{children}</>;
+  }
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/apps/web/components/file-upload.tsx
+++ b/apps/web/components/file-upload.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { UploadCloud } from 'lucide-react';
+
+import { uploadFitFile } from '../lib/api';
+import { Button } from './ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Input } from './ui/input';
+import { Alert, AlertDescription, AlertTitle } from './ui/alert';
+
+interface FileUploadProps {
+  onUploaded?: (activityId: string) => void;
+}
+
+export function FileUpload({ onUploaded }: FileUploadProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<'idle' | 'uploading' | 'error' | 'success'>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function handleUpload() {
+    if (!file) {
+      setMessage('Please choose a .FIT file to upload.');
+      setStatus('error');
+      return;
+    }
+    try {
+      setStatus('uploading');
+      setMessage(null);
+      const response = await uploadFitFile(file);
+      setStatus('success');
+      setMessage('Upload successful. Ready to compute metrics.');
+      onUploaded?.(response.activityId);
+    } catch (error) {
+      setStatus('error');
+      setMessage((error as Error).message);
+    }
+  }
+
+  return (
+    <Card className="max-w-xl">
+      <CardHeader>
+        <CardTitle className="flex items-center space-x-2">
+          <UploadCloud className="h-5 w-5" />
+          <span>Upload a Garmin FIT file</span>
+        </CardTitle>
+        <CardDescription>
+          We normalize your time series, store the ride, and let you compute extensible metrics like
+          the HR-to-Cadence Scaling Ratio.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Input
+          type="file"
+          accept=".fit"
+          onChange={(event) => {
+            const selected = event.target.files?.[0] ?? null;
+            setFile(selected);
+            setStatus('idle');
+            setMessage(null);
+          }}
+        />
+        <div className="flex items-center space-x-2">
+          <Button onClick={handleUpload} disabled={status === 'uploading'}>
+            {status === 'uploading' ? 'Uploading…' : 'Upload FIT file'}
+          </Button>
+          {file ? <span className="text-xs text-muted-foreground">{file.name}</span> : null}
+        </div>
+        {status !== 'idle' && message ? (
+          <Alert variant={status === 'error' ? 'destructive' : 'default'}>
+            <AlertTitle>{status === 'error' ? 'Upload failed' : 'Upload complete'}</AlertTitle>
+            <AlertDescription>{message}</AlertDescription>
+          </Alert>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/hcsr-chart.tsx
+++ b/apps/web/components/hcsr-chart.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Scatter,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface HcsrBucket {
+  cadenceMid: number;
+  medianHR: number;
+  seconds: number;
+  hr25?: number;
+  hr75?: number;
+}
+
+interface HcsrChartProps {
+  buckets: HcsrBucket[];
+  slope?: number | null;
+  intercept?: number | null;
+}
+
+export function HcsrChart({ buckets, slope, intercept }: HcsrChartProps) {
+  const data = buckets.map((bucket) => ({
+    cadence: bucket.cadenceMid,
+    medianHR: bucket.medianHR,
+    seconds: bucket.seconds,
+    fitted:
+      slope != null && intercept != null
+        ? Number.parseFloat((intercept + slope * bucket.cadenceMid).toFixed(2))
+        : null,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={320}>
+      <ComposedChart data={data} margin={{ top: 16, right: 24, bottom: 16, left: 16 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="cadence" unit="rpm" type="number" domain={['auto', 'auto']} />
+        <YAxis unit="bpm" domain={['auto', 'auto']} />
+        <Tooltip formatter={(value: unknown) => String(value)} />
+        <Legend />
+        <Scatter
+          dataKey="medianHR"
+          name="Median HR"
+          fill="hsl(var(--primary))"
+          shape="circle"
+        />
+        {slope != null && intercept != null ? (
+          <Line
+            type="monotone"
+            dataKey="fitted"
+            name="Fitted trend"
+            stroke="hsl(var(--secondary-foreground))"
+            strokeWidth={2}
+            dot={false}
+          />
+        ) : null}
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/web/components/landing-upload.tsx
+++ b/apps/web/components/landing-upload.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { FileUpload } from './file-upload';
+
+export function LandingUpload() {
+  const router = useRouter();
+
+  return (
+    <FileUpload
+      onUploaded={(activityId) => {
+        router.push(`/activities/${activityId}`);
+      }}
+    />
+  );
+}

--- a/apps/web/components/metric-summary-card.tsx
+++ b/apps/web/components/metric-summary-card.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+
+interface MetricSummaryCardProps {
+  title: string;
+  value: string | number | null | undefined;
+  description?: string;
+  units?: string | null;
+}
+
+export function MetricSummaryCard({ title, value, description, units }: MetricSummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">{title}</CardTitle>
+        {description ? <CardDescription>{description}</CardDescription> : null}
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold">
+          {value == null || Number.isNaN(Number(value)) ? '—' : value}
+          {units ? <span className="ml-1 text-base font-normal text-muted-foreground">{units}</span> : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { signIn, signOut, useSession } from 'next-auth/react';
+
+import { env } from '../lib/env';
+import { Button } from './ui/button';
+
+const navItems = [
+  { href: '/', label: 'Home' },
+  { href: '/activities', label: 'Activities' },
+  { href: '/metrics', label: 'Metrics' },
+];
+
+function AuthControls() {
+  const { status } = useSession();
+
+  if (status === 'loading') {
+    return <span className="text-sm text-muted-foreground">Loading...</span>;
+  }
+
+  if (status === 'authenticated') {
+    return (
+      <Button variant="ghost" size="sm" onClick={() => signOut()}>
+        Sign out
+      </Button>
+    );
+  }
+
+  return (
+    <Button variant="ghost" size="sm" onClick={() => signIn()}>
+      Sign in
+    </Button>
+  );
+}
+
+export function SiteHeader() {
+  const pathname = usePathname();
+
+  return (
+    <header className="border-b">
+      <div className="container mx-auto flex items-center justify-between px-4 py-4">
+        <Link href="/" className="text-lg font-semibold">
+          Cycling Custom Metrics
+        </Link>
+        <nav className="flex items-center space-x-4 text-sm font-medium">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={
+                pathname === item.href
+                  ? 'text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div>{env.authEnabled ? <AuthControls /> : null}</div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/components/ui/alert.tsx
+++ b/apps/web/components/ui/alert.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5 ref={ref} className={cn('mb-1 font-medium leading-none tracking-tight', className)} {...props} />
+));
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription };

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+));
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+));
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+));
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  ),
+);
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+));
+TableBody.displayName = 'TableBody';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn(
+        'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td
+      ref={ref}
+      className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+      {...props}
+    />
+  ),
+);
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+TableCaption.displayName = 'TableCaption';
+
+export { Table, TableHeader, TableBody, TableHead, TableRow, TableCell, TableCaption };

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,90 @@
+import { env } from './env';
+import type {
+  ActivitySummary,
+  ComputeMetricsResponse,
+  MetricDefinition,
+  MetricResultDetail,
+  PaginatedActivities,
+  UploadResponse,
+} from '../types/activity';
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const baseUrl =
+    typeof window === 'undefined' ? env.internalApiUrl ?? env.apiUrl : env.apiUrl;
+  const url = path.startsWith('http') ? path : `${baseUrl}${path}`;
+  const headers =
+    init?.body instanceof FormData
+      ? init?.headers
+      : { 'Content-Type': 'application/json', ...(init?.headers ?? {}) };
+
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      ...init,
+      headers,
+      cache: 'no-store',
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Unexpected error while contacting the metrics API';
+    throw new Error(
+      `${message}. Verify the backend is running at ${baseUrl} and accessible from the web app.`,
+    );
+  }
+
+  if (!response.ok) {
+    const message = await response
+      .json()
+      .catch(() => ({ error: response.statusText || 'Request failed' }));
+    throw new Error(
+      message.error || `Request failed with status ${response.status} from ${url}`,
+    );
+  }
+
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function uploadFitFile(file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+  return apiFetch<UploadResponse>('/upload', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+export async function fetchActivities(page = 1, pageSize = 10) {
+  const searchParams = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+  return apiFetch<PaginatedActivities>(`/activities?${searchParams.toString()}`);
+}
+
+export async function fetchActivity(activityId: string) {
+  return apiFetch<ActivitySummary>(`/activities/${activityId}`);
+}
+
+export async function computeMetrics(activityId: string, metricKeys?: string[]) {
+  return apiFetch<ComputeMetricsResponse>(`/activities/${activityId}/compute`, {
+    method: 'POST',
+    body: JSON.stringify(metricKeys ? { metricKeys } : {}),
+  });
+}
+
+export async function fetchMetricResult(activityId: string, metricKey: string) {
+  return apiFetch<MetricResultDetail>(`/activities/${activityId}/metrics/${metricKey}`);
+}
+
+export async function deleteActivity(activityId: string) {
+  await apiFetch<void>(`/activities/${activityId}`, { method: 'DELETE' });
+}
+
+export async function fetchMetricDefinitions() {
+  const response = await apiFetch<{ definitions: MetricDefinition[] }>(`/metrics`);
+  return response.definitions;
+}

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NEXT_PUBLIC_API_URL: z
+    .string()
+    .url()
+    .default('http://localhost:4000/api'),
+  NEXT_INTERNAL_API_URL: z.string().url().optional(),
+  NEXT_PUBLIC_AUTH_ENABLED: z
+    .enum(['true', 'false'])
+    .optional()
+    .default('false'),
+});
+
+const parsed = envSchema.parse({
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  NEXT_INTERNAL_API_URL: process.env.NEXT_INTERNAL_API_URL,
+  NEXT_PUBLIC_AUTH_ENABLED: process.env.NEXT_PUBLIC_AUTH_ENABLED,
+});
+
+export const env = {
+  apiUrl: parsed.NEXT_PUBLIC_API_URL,
+  internalApiUrl: parsed.NEXT_INTERNAL_API_URL ?? parsed.NEXT_PUBLIC_API_URL,
+  authEnabled: parsed.NEXT_PUBLIC_AUTH_ENABLED === 'true',
+};

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,12 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function formatDuration(seconds: number) {
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2",
+    "autoprefixer": "^10.4.16",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.308.0",
+    "next": "^14.1.0",
+    "next-auth": "^4.24.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.7.2",
+    "swr": "^2.2.4",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss": "^3.4.1",
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.43",
+    "@types/react-dom": "^18.2.17",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "^14.1.0",
+    "postcss": "^8.4.33",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,70 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "types": [
+      "node"
+    ],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/apps/web/types/activity.ts
+++ b/apps/web/types/activity.ts
@@ -1,0 +1,48 @@
+export interface MetricSummary {
+  key: string;
+  summary: Record<string, unknown>;
+  computedAt: string;
+}
+
+export interface ActivitySummary {
+  id: string;
+  source: string;
+  startTime: string;
+  durationSec: number;
+  sampleRateHz: number | null;
+  createdAt: string;
+  metrics: MetricSummary[];
+}
+
+export interface PaginatedActivities {
+  data: ActivitySummary[];
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export interface MetricDefinition {
+  key: string;
+  name: string;
+  version: number;
+  description: string;
+  units?: string | null;
+  computeConfig?: Record<string, unknown> | null;
+}
+
+export interface MetricResultDetail {
+  key: string;
+  definition: MetricDefinition;
+  summary: Record<string, unknown>;
+  series?: unknown;
+  computedAt: string;
+}
+
+export interface UploadResponse {
+  activityId: string;
+}
+
+export interface ComputeMetricsResponse {
+  activityId: string;
+  results: Record<string, unknown>;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: cyclingmetrics
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+  backend:
+    build:
+      context: .
+      dockerfile: apps/backend/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - postgres
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/cyclingmetrics
+      PORT: 4000
+      UPLOAD_DIR: /data/uploads
+      AUTH_ENABLED: 'false'
+      NEXTAUTH_SECRET: change-me
+    volumes:
+      - backend-uploads:/data/uploads
+    ports:
+      - '4000:4000'
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - backend
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:4000/api
+      NEXT_INTERNAL_API_URL: http://backend:4000/api
+      NEXT_PUBLIC_AUTH_ENABLED: 'false'
+      NEXTAUTH_SECRET: change-me
+      NEXTAUTH_URL: http://localhost:3000
+    ports:
+      - '3000:3000'
+volumes:
+  postgres-data:
+  backend-uploads:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cycling-custom-metrics",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"pnpm --filter backend dev\" \"pnpm --filter web dev\"",
+    "lint": "pnpm -r lint",
+    "test": "pnpm -r test",
+    "typecheck": "pnpm -r typecheck",
+    "db:push": "pnpm --filter backend db:push",
+    "db:migrate": "pnpm --filter backend db:migrate",
+    "seed": "pnpm --filter backend seed"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## Summary
- update the shared API helper to fall back to the internal API base URL on the server and surface actionable guidance when the backend cannot be reached
- guard the activities index page against fetch failures so it renders an in-app alert instead of crashing during SSR

## Testing
- pnpm --filter web lint *(fails: Next.js binary missing because dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a3886228833080bc8653e68e1c50