### PR TITLE
Allow FIT parser warnings without failing ingest

### DIFF
--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,11 +1,10 @@
-import { Prisma } from '@prisma/client';
-
 import { prisma } from '../src/prisma.js';
 import { metricRegistry } from '../src/metrics/registry.js';
+import { normalizeNullableJson } from '../src/utils/prismaJson.js';
 
 async function main() {
   for (const module of Object.values(metricRegistry)) {
-    const computeConfig = module.definition.computeConfig ?? Prisma.JsonNull;
+    const computeConfig = normalizeNullableJson(module.definition.computeConfig);
     await prisma.metricDefinition.upsert({
       where: { key: module.definition.key },
       update: {

--- a/apps/backend/src/parsers/fit.ts
+++ b/apps/backend/src/parsers/fit.ts
@@ -69,6 +69,11 @@ async function parseFitBuffer(fileBuffer: Buffer): Promise<{
         return;
       }
 
+      if (!parsed || typeof parsed !== 'object') {
+        resolve({});
+        return;
+      }
+
       resolve(parsed);
     });
   });

--- a/apps/backend/src/routes/upload.ts
+++ b/apps/backend/src/routes/upload.ts
@@ -13,7 +13,7 @@ const storage = multer.diskStorage({
     fs
       .mkdir(env.UPLOAD_DIR, { recursive: true })
       .then(() => cb(null, env.UPLOAD_DIR))
-      .catch((error: unknown) => cb(error as Error));
+      .catch((error: unknown) => cb(error as Error, env.UPLOAD_DIR));
   },
   filename: (_req, file, cb) => {
     const safeName = file.originalname.toLowerCase().replace(/[^a-z0-9_.-]+/g, '-');

--- a/apps/backend/src/routes/upload.ts
+++ b/apps/backend/src/routes/upload.ts
@@ -10,7 +10,10 @@ import { ingestFitFile } from '../services/ingestService.js';
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => {
-    cb(null, env.UPLOAD_DIR);
+    fs
+      .mkdir(env.UPLOAD_DIR, { recursive: true })
+      .then(() => cb(null, env.UPLOAD_DIR))
+      .catch((error: unknown) => cb(error as Error));
   },
   filename: (_req, file, cb) => {
     const safeName = file.originalname.toLowerCase().replace(/[^a-z0-9_.-]+/g, '-');

--- a/apps/backend/src/types/fit-file-parser.d.ts
+++ b/apps/backend/src/types/fit-file-parser.d.ts
@@ -1,0 +1,1 @@
+declare module 'fit-file-parser';

--- a/apps/backend/src/utils/prismaJson.ts
+++ b/apps/backend/src/utils/prismaJson.ts
@@ -1,0 +1,15 @@
+import { Prisma } from '@prisma/client';
+
+export function normalizeNullableJson(
+  value: unknown,
+): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
+  if (value === null || value === undefined) {
+    return Prisma.JsonNull;
+  }
+
+  return value as Prisma.InputJsonValue;
+}
+
+export function normalizeSummaryJson(summary: Record<string, unknown>): Prisma.JsonObject {
+  return summary as Prisma.JsonObject;
+}

--- a/apps/backend/tests/hcsrMetric.test.ts
+++ b/apps/backend/tests/hcsrMetric.test.ts
@@ -43,12 +43,15 @@ describe('hcsrMetric', () => {
       createdAt: new Date(),
     } as const;
 
-    const result = hcsrMetric.compute(samples, { activity });
+    const computation = hcsrMetric.compute(samples, { activity });
+    if (computation instanceof Promise) {
+      throw new Error('hcsrMetric.compute should resolve synchronously during this test');
+    }
 
-    expect(result.summary.slope_bpm_per_rpm).toBeDefined();
-    expect(result.summary.slope_bpm_per_rpm).toBeGreaterThan(0.4);
-    expect(result.summary.r2).toBeGreaterThan(0.9);
-    expect(result.summary.bucket_count).toBe(4);
-    expect(Array.isArray(result.series)).toBe(true);
+    expect(computation.summary.slope_bpm_per_rpm).toBeDefined();
+    expect(computation.summary.slope_bpm_per_rpm).toBeGreaterThan(0.4);
+    expect(computation.summary.r2).toBeGreaterThan(0.9);
+    expect(computation.summary.bucket_count).toBe(4);
+    expect(Array.isArray(computation.series)).toBe(true);
   });
 });

--- a/apps/backend/tests/parseFitFile.test.ts
+++ b/apps/backend/tests/parseFitFile.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { parseFitFile } from '../src/parsers/fit.js';
 
 let mockRecords: any[] = [];
+let parserBehavior: ((callback: (error: unknown, data: any) => void) => void) | null = null;
 
 vi.mock('fit-file-parser', () => {
   return {
     default: class FitParser {
       parse(_buffer: Buffer, callback: (error: unknown, data: any) => void) {
+        if (parserBehavior) {
+          parserBehavior(callback);
+          return;
+        }
+
         callback('File to small to be a FIT file', {});
         callback(null, { records: mockRecords });
       }
@@ -46,6 +52,7 @@ describe('parseFitFile', () => {
         enhanced_altitude: 103,
       },
     ];
+    parserBehavior = null;
   });
 
   it('normalizes samples to a 1Hz grid with forward fill on small gaps', async () => {
@@ -58,5 +65,15 @@ describe('parseFitFile', () => {
     expect(activity.samples[2].heartRate).toBe(activity.samples[1].heartRate);
     expect(activity.samples[3].heartRate).toBe(activity.samples[1].heartRate);
     expect(activity.durationSec).toBe(4);
+  });
+
+  it('throws a friendly error when the parser returns no data object', async () => {
+    parserBehavior = (callback) => {
+      callback(null, undefined);
+    };
+
+    await expect(parseFitFile(fixturePath)).rejects.toThrow(
+      'FIT file has no timestamped records.',
+    );
   });
 });

--- a/apps/backend/tests/parseFitFile.test.ts
+++ b/apps/backend/tests/parseFitFile.test.ts
@@ -8,6 +8,7 @@ vi.mock('fit-file-parser', () => {
   return {
     default: class FitParser {
       parse(_buffer: Buffer, callback: (error: unknown, data: any) => void) {
+        callback('File to small to be a FIT file', {});
         callback(null, { records: mockRecords });
       }
     },

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "./",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/apps/web/app/metrics/page.tsx
+++ b/apps/web/app/metrics/page.tsx
@@ -1,5 +1,6 @@
 import { env } from '../../lib/env';
 import type { MetricDefinition } from '../../types/activity';
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 
 async function getMetricDefinitions(): Promise<MetricDefinition[]> {
@@ -14,41 +15,56 @@ async function getMetricDefinitions(): Promise<MetricDefinition[]> {
 }
 
 export default async function MetricsPage() {
-  const definitions = await getMetricDefinitions();
+  try {
+    const definitions = await getMetricDefinitions();
 
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold">Metric registry</h1>
-        <p className="text-muted-foreground">
-          Each metric is self-contained with a definition, compute function, and Vitest coverage.
-        </p>
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">Metric registry</h1>
+          <p className="text-muted-foreground">
+            Each metric is self-contained with a definition, compute function, and Vitest coverage.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {definitions.map((definition) => (
+            <Card key={definition.key}>
+              <CardHeader>
+                <CardTitle className="text-base font-semibold">
+                  {definition.name}
+                  <span className="ml-2 text-xs text-muted-foreground">v{definition.version}</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-muted-foreground">
+                <p>{definition.description}</p>
+                {definition.units ? (
+                  <p>
+                    <span className="font-medium text-foreground">Units:</span> {definition.units}
+                  </p>
+                ) : null}
+                {definition.computeConfig ? (
+                  <pre className="rounded-md bg-muted p-3 text-xs">
+                    {JSON.stringify(definition.computeConfig, null, 2)}
+                  </pre>
+                ) : null}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
-      <div className="grid gap-4 md:grid-cols-2">
-        {definitions.map((definition) => (
-          <Card key={definition.key}>
-            <CardHeader>
-              <CardTitle className="text-base font-semibold">
-                {definition.name}
-                <span className="ml-2 text-xs text-muted-foreground">v{definition.version}</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm text-muted-foreground">
-              <p>{definition.description}</p>
-              {definition.units ? (
-                <p>
-                  <span className="font-medium text-foreground">Units:</span> {definition.units}
-                </p>
-              ) : null}
-              {definition.computeConfig ? (
-                <pre className="rounded-md bg-muted p-3 text-xs">
-                  {JSON.stringify(definition.computeConfig, null, 2)}
-                </pre>
-              ) : null}
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    </div>
-  );
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown error while fetching metric definitions.';
+
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Unable to load metric registry</AlertTitle>
+        <AlertDescription>
+          {message}. Ensure the backend API is running and the metric definitions have been seeded{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">pnpm seed</code>.
+        </AlertDescription>
+      </Alert>
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- treat string-based warnings from `fit-file-parser` as non-fatal so FIT uploads complete successfully
- log parser warnings for observability and ensure the upload directory exists before saving files
- extend the parser unit test to cover the warning-first callback behaviour

## Testing
- DATABASE_URL=postgresql://localhost:5432/test pnpm --filter backend test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d3fea71ef08330be07bac507d06746