### PR TITLE
feat: add authenticated user profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,8 @@ Key variables:
 
 ### Authentication
 
-Set `AUTH_ENABLED=true` (backend) and `NEXT_PUBLIC_AUTH_ENABLED=true` (frontend) to require sign-in. Users can self-register via
-the `/register` page, which creates a credentials-based account, generates a JWT for API access, and automatically signs them in.
-Authenticated requests include a `Bearer` token, and the API scopes activities, uploads, metric recomputations, and history
-queries to the requesting user.
+- **Open mode** – leave `AUTH_ENABLED=false` and `NEXT_PUBLIC_AUTH_ENABLED=false` (the defaults) to skip authentication entirely. Uploads, metrics, and activities are shared across visitors which keeps local demos frictionless.
+- **Protected mode** – set `AUTH_ENABLED=true` in the backend `.env` and `NEXT_PUBLIC_AUTH_ENABLED=true` in the frontend `.env` to require registration and login. New users can sign up via `/register` and will be redirected to `/profile` after signing in to complete their display name, avatar, and bio. All API calls (uploads, activity history, metric recomputations) are automatically scoped to the authenticated user via bearer tokens issued by the backend.
 
 ### Database
 

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -14,6 +14,18 @@ model User {
   provider     String?
   createdAt    DateTime   @default(now())
   activities   Activity[]
+  profile      Profile?
+}
+
+model Profile {
+  id          String   @id @default(cuid())
+  userId      String   @unique
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  displayName String?
+  avatarUrl   String?
+  bio         String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model Activity {

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 
+import { requireAuth } from '../middleware/auth.js';
+
 import { activitiesRouter } from './activities.js';
 import { authRouter } from './auth.js';
 import { metricsRouter } from './metrics.js';
+import { profileRouter } from './profile.js';
 import { uploadRouter } from './upload.js';
-import { requireAuth } from '../middleware/auth.js';
 
 export const apiRouter = express.Router();
 
@@ -12,3 +14,4 @@ apiRouter.use('/auth', authRouter);
 apiRouter.use('/upload', requireAuth, uploadRouter);
 apiRouter.use('/activities', requireAuth, activitiesRouter);
 apiRouter.use('/metrics', requireAuth, metricsRouter);
+apiRouter.use('/profile', requireAuth, profileRouter);

--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -1,0 +1,88 @@
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
+
+import { env } from '../env.js';
+import { prisma } from '../prisma.js';
+
+const profileUpdateSchema = z.object({
+  displayName: z.string().trim().min(1).max(100).optional().nullable(),
+  avatarUrl: z.string().trim().url().max(2048).optional().nullable(),
+  bio: z.string().trim().max(1000).optional().nullable(),
+});
+
+function toNullable<T>(value: T | undefined | null): T | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === 'string' && value.trim().length === 0) {
+    return null;
+  }
+  return value;
+}
+
+export const profileRouter = express.Router();
+
+profileRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    if (env.AUTH_ENABLED && !req.user?.id) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const userId = req.user?.id;
+    if (!userId) {
+      res.json(null);
+      return;
+    }
+
+    const profile = await prisma.profile.upsert({
+      where: { userId },
+      create: { userId },
+      update: {},
+    });
+
+    res.json(profile);
+  }),
+);
+
+profileRouter.put(
+  '/',
+  asyncHandler(async (req, res) => {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const payload = {
+      displayName: toNullable(req.body.displayName),
+      avatarUrl: toNullable(req.body.avatarUrl),
+      bio: toNullable(req.body.bio),
+    };
+
+    const parsed = profileUpdateSchema.safeParse(payload);
+    if (!parsed.success) {
+      const errorMessage =
+        parsed.error.errors.at(0)?.message ?? 'Invalid profile details provided.';
+      res.status(400).json({ error: errorMessage });
+      return;
+    }
+
+    const data = parsed.data;
+
+    const cleanedEntries = Object.entries(data).filter(([, value]) => value !== undefined);
+    const updateData = Object.fromEntries(cleanedEntries);
+
+    const profile = await prisma.profile.upsert({
+      where: { userId: req.user.id },
+      create: { userId: req.user.id, ...updateData },
+      update: updateData,
+    });
+
+    res.json(profile);
+  }),
+);

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,0 +1,79 @@
+import { redirect } from 'next/navigation';
+
+import { ProfileForm } from '../../components/profile-form';
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
+import { getServerAuthSession } from '../../lib/auth';
+import { env } from '../../lib/env';
+import type { Profile } from '../../types/profile';
+
+async function loadProfile(token?: string): Promise<Profile | null> {
+  if (!token) {
+    return null;
+  }
+
+  const response = await fetch(`${env.internalApiUrl}/profile`, {
+    cache: 'no-store',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load profile');
+  }
+
+  return (await response.json()) as Profile | null;
+}
+
+export default async function ProfilePage() {
+  const session = await getServerAuthSession();
+
+  if (env.authEnabled && !session) {
+    redirect('/signin');
+  }
+
+  if (!env.authEnabled) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">Profile</h1>
+          <p className="text-muted-foreground">
+            Profiles are disabled while authentication is turned off.
+          </p>
+        </div>
+        <Alert>
+          <AlertTitle>Authentication disabled</AlertTitle>
+          <AlertDescription>
+            Set <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">AUTH_ENABLED=true</code> in the backend and
+            <code className="ml-1 rounded bg-muted px-1 py-0.5 font-mono text-xs">NEXT_PUBLIC_AUTH_ENABLED=true</code> in the
+            frontend to enable sign-in and user profiles.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  try {
+    const profile = await loadProfile(session?.accessToken);
+
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">Profile</h1>
+          <p className="text-muted-foreground">
+            Update how your name, photo, and bio appear across Cycling Custom Metrics.
+          </p>
+        </div>
+        <ProfileForm profile={profile} authToken={session?.accessToken} />
+      </div>
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error while fetching profile.';
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Unable to load profile</AlertTitle>
+        <AlertDescription>{message}</AlertDescription>
+      </Alert>
+    );
+  }
+}

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -12,7 +12,7 @@ export default async function RegisterPage() {
 
   const session = await getServerAuthSession();
   if (session) {
-    redirect('/activities');
+    redirect('/profile');
   }
 
   return (

--- a/apps/web/app/signin/page.tsx
+++ b/apps/web/app/signin/page.tsx
@@ -12,7 +12,7 @@ export default async function SignInPage() {
 
   const session = await getServerAuthSession();
   if (session) {
-    redirect('/activities');
+    redirect('/profile');
   }
 
   return (

--- a/apps/web/components/profile-form.tsx
+++ b/apps/web/components/profile-form.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+
+import { updateProfile } from '../lib/api';
+import type { Profile } from '../types/profile';
+import { Alert, AlertDescription } from './ui/alert';
+import { Button } from './ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Input } from './ui/input';
+
+interface ProfileFormProps {
+  profile: Profile | null;
+  authToken?: string;
+}
+
+export function ProfileForm({ profile, authToken }: ProfileFormProps) {
+  const [displayName, setDisplayName] = useState(profile?.displayName ?? '');
+  const [avatarUrl, setAvatarUrl] = useState(profile?.avatarUrl ?? '');
+  const [bio, setBio] = useState(profile?.bio ?? '');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setIsSaving(true);
+
+    try {
+      const updates = {
+        displayName: displayName.trim().length > 0 ? displayName.trim() : null,
+        avatarUrl: avatarUrl.trim().length > 0 ? avatarUrl.trim() : null,
+        bio: bio.trim().length > 0 ? bio.trim() : null,
+      };
+
+      const updated = await updateProfile(updates, authToken);
+      setDisplayName(updated.displayName ?? '');
+      setAvatarUrl(updated.avatarUrl ?? '');
+      setBio(updated.bio ?? '');
+      setSuccess('Profile updated successfully.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update profile.';
+      setError(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Profile details</CardTitle>
+        <CardDescription>Control how your name and bio appear across the app.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-foreground" htmlFor="displayName">
+              Display name
+            </label>
+            <Input
+              id="displayName"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              placeholder="e.g. Climbs with Coffee"
+              maxLength={100}
+            />
+            <p className="text-xs text-muted-foreground">Shown on activity uploads and leaderboards.</p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-foreground" htmlFor="avatarUrl">
+              Avatar URL
+            </label>
+            <Input
+              id="avatarUrl"
+              value={avatarUrl}
+              onChange={(event) => setAvatarUrl(event.target.value)}
+              placeholder="https://example.com/avatar.jpg"
+              maxLength={2048}
+            />
+            <p className="text-xs text-muted-foreground">Optional image used in future social features.</p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-foreground" htmlFor="bio">
+              Bio
+            </label>
+            <textarea
+              id="bio"
+              value={bio}
+              onChange={(event) => setBio(event.target.value)}
+              rows={4}
+              maxLength={1000}
+              className="flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <p className="text-xs text-muted-foreground">Up to 1,000 characters about your training goals.</p>
+          </div>
+
+          {error ? (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+          {success ? (
+            <Alert>
+              <AlertDescription>{success}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button type="submit" disabled={isSaving}>
+            {isSaving ? 'Saving…' : 'Save profile'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/register-form.tsx
+++ b/apps/web/components/register-form.tsx
@@ -48,7 +48,7 @@ export function RegisterForm() {
         return;
       }
 
-      router.push('/activities');
+      router.push('/profile');
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/apps/web/components/sign-in-form.tsx
+++ b/apps/web/components/sign-in-form.tsx
@@ -28,7 +28,7 @@ export function SignInForm() {
         redirect: false,
         email: normalizedEmail,
         password,
-        callbackUrl: searchParams.get('callbackUrl') ?? '/activities',
+        callbackUrl: searchParams.get('callbackUrl') ?? '/profile',
       });
 
       if (result?.error) {
@@ -36,7 +36,7 @@ export function SignInForm() {
         return;
       }
 
-      router.push(result?.url ?? '/activities');
+      router.push(result?.url ?? '/profile');
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -7,7 +7,7 @@ import { signIn, signOut, useSession } from 'next-auth/react';
 import { env } from '../lib/env';
 import { Button } from './ui/button';
 
-const navItems = [
+const baseNavItems = [
   { href: '/', label: 'Home' },
   { href: '/activities', label: 'Activities' },
   { href: '/metrics', label: 'Metrics' },
@@ -42,6 +42,10 @@ function AuthControls() {
 
 export function SiteHeader() {
   const pathname = usePathname();
+  const { status } = useSession();
+
+  const navItems =
+    status === 'authenticated' ? [...baseNavItems, { href: '/profile', label: 'Profile' }] : baseNavItems;
 
   return (
     <header className="border-b">

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   IntervalEfficiencyResponse,
   IntervalEfficiencyHistoryResponse,
 } from '../types/activity';
+import type { Profile } from '../types/profile';
 
 async function apiFetch<T>(path: string, init?: RequestInit, authToken?: string): Promise<T> {
   const url = path.startsWith('http') ? path : `${env.apiUrl}${path}`;
@@ -112,5 +113,23 @@ export async function registerUserAccount(email: string, password: string) {
       method: 'POST',
       body: JSON.stringify({ email, password }),
     },
+  );
+}
+
+export async function fetchProfile(authToken?: string) {
+  return apiFetch<Profile | null>('/profile', undefined, authToken);
+}
+
+export async function updateProfile(
+  updates: { displayName: string | null; avatarUrl: string | null; bio: string | null },
+  authToken?: string,
+) {
+  return apiFetch<Profile>(
+    '/profile',
+    {
+      method: 'PUT',
+      body: JSON.stringify(updates),
+    },
+    authToken,
   );
 }

--- a/apps/web/types/profile.ts
+++ b/apps/web/types/profile.ts
@@ -1,0 +1,9 @@
+export interface Profile {
+  id: string;
+  userId: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  bio: string | null;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- add a Prisma-backed Profile model and secure profile API routes
- build a profile management page with editing form and navigation updates
- document auth toggles and redirect sign-in/register flows to the profile page

## Testing
- pnpm lint *(fails: existing eslint config cannot parse TypeScript source files)*
- pnpm typecheck *(fails: existing backend type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d30534708330b0268f63860425ca