### PR TITLE
Add late-ride aerobic efficiency metric

### DIFF
--- a/apps/backend/src/metrics/lateAerobicEfficiency.ts
+++ b/apps/backend/src/metrics/lateAerobicEfficiency.ts
@@ -1,0 +1,109 @@
+import type { MetricModule } from './types.js';
+
+const ANALYSIS_WINDOW_MINUTES = 35;
+const FINAL_BUFFER_MINUTES = 5;
+
+const ANALYSIS_WINDOW_SECONDS = ANALYSIS_WINDOW_MINUTES * 60;
+const FINAL_BUFFER_SECONDS = FINAL_BUFFER_MINUTES * 60;
+
+function round(value: number, fractionDigits: number) {
+  const factor = 10 ** fractionDigits;
+  return Math.round(value * factor) / factor;
+}
+
+function clampWindow(start: number, end: number) {
+  if (end <= 0) {
+    return { start: 0, end: 0 };
+  }
+  const clampedStart = Math.max(0, Math.min(start, end));
+  return { start: clampedStart, end };
+}
+
+export const lateAerobicEfficiencyMetric: MetricModule = {
+  definition: {
+    key: 'late-aerobic-efficiency',
+    name: 'Late-ride Aerobic Efficiency',
+    version: 1,
+    description:
+      'Evaluates aerobic durability by averaging power-to-heart-rate efficiency over the final 35 minutes (excluding the last 5 minutes).',
+    units: 'W/bpm',
+    computeConfig: {
+      analysisWindowMinutes: ANALYSIS_WINDOW_MINUTES,
+      exclusionBufferMinutes: FINAL_BUFFER_MINUTES,
+    },
+  },
+  compute: (samples, context) => {
+    const { activity } = context;
+    const durationSec =
+      typeof activity.durationSec === 'number' && !Number.isNaN(activity.durationSec)
+        ? activity.durationSec
+        : samples.length > 0
+          ? samples[samples.length - 1]?.t ?? 0
+          : 0;
+
+    const requestedStart = durationSec - ANALYSIS_WINDOW_SECONDS;
+    const requestedEnd = durationSec - FINAL_BUFFER_SECONDS;
+    const { start: windowStart, end: windowEnd } = clampWindow(requestedStart, requestedEnd);
+
+    if (windowEnd <= windowStart) {
+      return {
+        summary: {
+          watts_per_bpm: null,
+          average_power_w: null,
+          average_heart_rate_bpm: null,
+          valid_sample_count: 0,
+          total_window_sample_count: 0,
+          requested_window_seconds: ANALYSIS_WINDOW_SECONDS,
+          analyzed_window_seconds: 0,
+          window_start_offset_sec: Math.max(0, windowStart),
+          window_end_offset_sec: Math.max(0, windowEnd),
+        },
+      };
+    }
+
+    const windowSamples = samples.filter((sample) => sample.t >= windowStart && sample.t < windowEnd);
+    const totalWindowSampleCount = windowSamples.length;
+
+    const validSamples = windowSamples.filter((sample) => sample.power != null && sample.heartRate != null);
+
+    const validSampleCount = validSamples.length;
+
+    if (validSampleCount === 0) {
+      return {
+        summary: {
+          watts_per_bpm: null,
+          average_power_w: null,
+          average_heart_rate_bpm: null,
+          valid_sample_count: 0,
+          total_window_sample_count: totalWindowSampleCount,
+          requested_window_seconds: ANALYSIS_WINDOW_SECONDS,
+          analyzed_window_seconds: windowEnd - windowStart,
+          window_start_offset_sec: Math.max(0, windowStart),
+          window_end_offset_sec: Math.max(0, windowEnd),
+        },
+      };
+    }
+
+    const powerSum = validSamples.reduce((sum, sample) => sum + (sample.power ?? 0), 0);
+    const hrSum = validSamples.reduce((sum, sample) => sum + (sample.heartRate ?? 0), 0);
+
+    const averagePower = powerSum / validSampleCount;
+    const averageHeartRate = hrSum / validSampleCount;
+
+    const wattsPerBpm = averageHeartRate > 0 ? averagePower / averageHeartRate : null;
+
+    return {
+      summary: {
+        watts_per_bpm: wattsPerBpm != null ? round(wattsPerBpm, 3) : null,
+        average_power_w: round(averagePower, 1),
+        average_heart_rate_bpm: round(averageHeartRate, 1),
+        valid_sample_count: validSampleCount,
+        total_window_sample_count: totalWindowSampleCount,
+        requested_window_seconds: ANALYSIS_WINDOW_SECONDS,
+        analyzed_window_seconds: windowEnd - windowStart,
+        window_start_offset_sec: Math.max(0, windowStart),
+        window_end_offset_sec: Math.max(0, windowEnd),
+      },
+    };
+  },
+};

--- a/apps/backend/src/metrics/registry.ts
+++ b/apps/backend/src/metrics/registry.ts
@@ -3,6 +3,7 @@ import { intervalEfficiencyMetric } from './intervalEfficiency.js';
 import { torqueVariabilityIndexMetric } from './tvi.js';
 import { whrEfficiencyMetric } from './whrEfficiency.js';
 import { normalizedPowerMetric } from './normalizedPower.js';
+import { lateAerobicEfficiencyMetric } from './lateAerobicEfficiency.js';
 import type { MetricModule } from './types.js';
 
 export const metricRegistry: Record<string, MetricModule> = {
@@ -11,6 +12,7 @@ export const metricRegistry: Record<string, MetricModule> = {
   [torqueVariabilityIndexMetric.definition.key]: torqueVariabilityIndexMetric,
   [whrEfficiencyMetric.definition.key]: whrEfficiencyMetric,
   [normalizedPowerMetric.definition.key]: normalizedPowerMetric,
+  [lateAerobicEfficiencyMetric.definition.key]: lateAerobicEfficiencyMetric,
 };
 
 export function listMetricDefinitions() {

--- a/apps/backend/tests/lateAerobicEfficiencyMetric.test.ts
+++ b/apps/backend/tests/lateAerobicEfficiencyMetric.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { lateAerobicEfficiencyMetric } from '../src/metrics/lateAerobicEfficiency.js';
+import type { MetricSample } from '../src/metrics/types.js';
+
+describe('lateAerobicEfficiencyMetric', () => {
+  it('computes watts per bpm for the late-ride window', () => {
+    const totalMinutes = 120;
+    const totalSeconds = totalMinutes * 60;
+
+    const samples: MetricSample[] = Array.from({ length: totalSeconds }, (_, index) => {
+      const t = index;
+      const inWindow = t >= totalSeconds - 2100 && t < totalSeconds - 300;
+      return {
+        t,
+        power: inWindow ? 210 : 180,
+        heartRate: inWindow ? 140 : 125,
+        cadence: null,
+        speed: null,
+        elevation: null,
+      };
+    });
+
+    const activity = {
+      id: 'act_1',
+      userId: null,
+      source: 'test',
+      startTime: new Date(),
+      durationSec: totalSeconds,
+      sampleRateHz: 1,
+      createdAt: new Date(),
+    } as const;
+
+    const computation = lateAerobicEfficiencyMetric.compute(samples, { activity });
+    if (computation instanceof Promise) {
+      throw new Error('Metric should compute synchronously in this test');
+    }
+
+    expect(computation.summary.watts_per_bpm).toBeCloseTo(1.5, 3);
+    expect(computation.summary.average_power_w).toBeCloseTo(210);
+    expect(computation.summary.average_heart_rate_bpm).toBeCloseTo(140);
+    expect(computation.summary.valid_sample_count).toBe(1800);
+    expect(computation.summary.total_window_sample_count).toBe(1800);
+  });
+
+  it('handles missing data gracefully', () => {
+    const samples: MetricSample[] = Array.from({ length: 1000 }, (_, index) => ({
+      t: index,
+      power: index < 700 ? null : 200,
+      heartRate: null,
+      cadence: null,
+      speed: null,
+      elevation: null,
+    }));
+
+    const activity = {
+      id: 'act_2',
+      userId: null,
+      source: 'test',
+      startTime: new Date(),
+      durationSec: 1000,
+      sampleRateHz: 1,
+      createdAt: new Date(),
+    } as const;
+
+    const computation = lateAerobicEfficiencyMetric.compute(samples, { activity });
+    if (computation instanceof Promise) {
+      throw new Error('Metric should compute synchronously in this test');
+    }
+
+    expect(computation.summary.watts_per_bpm).toBeNull();
+    expect(computation.summary.average_power_w).toBeNull();
+    expect(computation.summary.average_heart_rate_bpm).toBeNull();
+    expect(computation.summary.valid_sample_count).toBe(0);
+    expect(computation.summary.total_window_sample_count).toBeGreaterThan(0);
+  });
+});

--- a/apps/backend/tests/registry.test.ts
+++ b/apps/backend/tests/registry.test.ts
@@ -9,6 +9,7 @@ describe('metric registry', () => {
     expect(metricRegistry).toHaveProperty('tvi');
     expect(metricRegistry).toHaveProperty('whr-efficiency');
     expect(metricRegistry).toHaveProperty('normalized-power');
+    expect(metricRegistry).toHaveProperty('late-aerobic-efficiency');
 
     const definitions = listMetricDefinitions();
     const keys = definitions.map((definition) => definition.key);
@@ -17,5 +18,6 @@ describe('metric registry', () => {
     expect(keys).toContain('tvi');
     expect(keys).toContain('whr-efficiency');
     expect(keys).toContain('normalized-power');
+    expect(keys).toContain('late-aerobic-efficiency');
   });
 });

--- a/apps/web/app/activities/[id]/page.tsx
+++ b/apps/web/app/activities/[id]/page.tsx
@@ -57,6 +57,24 @@ async function getNormalizedPowerMetric(
   return (await response.json()) as MetricResultDetail;
 }
 
+async function getLateAerobicMetric(id: string, token?: string): Promise<MetricResultDetail | null> {
+  const headers: HeadersInit | undefined = token ? { Authorization: `Bearer ${token}` } : undefined;
+  const response = await fetch(
+    `${env.internalApiUrl}/activities/${id}/metrics/late-aerobic-efficiency`,
+    {
+      cache: 'no-store',
+      headers,
+    },
+  );
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error('Failed to load late-ride aerobic efficiency metric');
+  }
+  return (await response.json()) as MetricResultDetail;
+}
+
 async function getIntervalEfficiency(
   id: string,
   token?: string,
@@ -89,11 +107,12 @@ export default async function ActivityDetailPage({
   }
 
   const token = session?.accessToken;
-  const [activity, hcsr, intervalEfficiency, normalizedPower] = await Promise.all([
+  const [activity, hcsr, intervalEfficiency, normalizedPower, lateAerobic] = await Promise.all([
     getActivity(params.id, token),
     getHcsrMetric(params.id, token),
     getIntervalEfficiency(params.id, token),
     getNormalizedPowerMetric(params.id, token),
+    getLateAerobicMetric(params.id, token),
   ]);
 
   return (
@@ -102,6 +121,7 @@ export default async function ActivityDetailPage({
       initialHcsr={hcsr}
       initialIntervalEfficiency={intervalEfficiency}
       initialNormalizedPower={normalizedPower}
+      initialLateAerobicEfficiency={lateAerobic}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add a late-ride aerobic efficiency metric that analyzes watts-per-bpm over the final durability window
- register and cover the new metric with unit tests alongside registry updates
- surface the metric on the activity detail page with summary cards and contextual window details

## Testing
- pnpm --filter backend test
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8c27b816883309039ab4a13d6dbcf