### PR TITLE
Fix Zod int chaining order in profile schema

### DIFF
--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -23,10 +23,10 @@ const profileUpdateSchema = z.object({
   achievements: z.string().trim().max(500).optional().nullable(),
   weeklyGoalHours: z
     .number({ invalid_type_error: 'Weekly training goal must be a number.' })
+    .int('Weekly training goal must be a whole number of hours.')
     .refine((value) => Number.isFinite(value), {
       message: 'Weekly training goal must be a number.',
     })
-    .int('Weekly training goal must be a whole number of hours.')
     .min(0, 'Weekly training goal cannot be negative.')
     .max(80, 'Weekly training goal must be 80 hours or less.')
     .optional()


### PR DESCRIPTION
## Summary
- ensure the weekly goal hours validator calls `.int()` before `.refine()` so the method exists on the schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d4e8d3348330ad1e533d9881c6a6