### PR TITLE
Fix number schema constraints order in profile route

### DIFF
--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -24,11 +24,11 @@ const profileUpdateSchema = z.object({
   weeklyGoalHours: z
     .number({ invalid_type_error: 'Weekly training goal must be a number.' })
     .int('Weekly training goal must be a whole number of hours.')
+    .min(0, 'Weekly training goal cannot be negative.')
+    .max(80, 'Weekly training goal must be 80 hours or less.')
     .refine((value) => Number.isFinite(value), {
       message: 'Weekly training goal must be a number.',
     })
-    .min(0, 'Weekly training goal cannot be negative.')
-    .max(80, 'Weekly training goal must be 80 hours or less.')
     .optional()
     .nullable(),
 });


### PR DESCRIPTION
## Summary
- ensure number schema constraints for weeklyGoalHours apply base checks before refine to avoid runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d5f9c5588330b4883e20838ef7cd