### PR TITLE
Fix tooltip styling for dark mode tooltips

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -75,3 +75,16 @@ body {
 * {
   border-color: hsl(var(--border));
 }
+
+.recharts-default-tooltip {
+  background-color: hsl(var(--popover)) !important;
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  box-shadow: 0 10px 30px -15px hsl(var(--background) / 0.45);
+}
+
+.recharts-tooltip-label,
+.recharts-tooltip-item-list .recharts-tooltip-item {
+  color: hsl(var(--popover-foreground));
+}


### PR DESCRIPTION
## Summary
- align global Recharts tooltip styling with the app's themed popover colors
- ensure tooltip text inherits readable foreground hues and rounded corners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dd63cd9883309d6c77046f3647f2