### PR TITLE
Enable authentication and profiles by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cyclingmetrics
 PORT=4000
 UPLOAD_DIR=./uploads
-AUTH_ENABLED=false
+AUTH_ENABLED=true
 NEXTAUTH_SECRET=please-change-me
 JWT_SECRET=please-change-me
 DEMO_USER_EMAIL=demo@cyclingmetrics.dev
@@ -11,4 +11,4 @@ DEMO_USER_PASSWORD=demo
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:4000/api
 NEXT_INTERNAL_API_URL=http://backend:4000/api
-NEXT_PUBLIC_AUTH_ENABLED=false
+NEXT_PUBLIC_AUTH_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cycling Custom Metrics is a full-stack TypeScript application that ingests Garmi
 - **Garmin FIT ingestion** using `fit-file-parser` with resampling to 1 Hz, forward filling of small gaps, and sample sanitation.
 - **Extensible metric engine** – add a single file under `apps/backend/src/metrics` to define new metrics, compute logic, and tests.
 - **Next.js 14 App Router UI** styled with TailwindCSS and shadcn/ui components. Includes upload flow, activity list, detail dashboard with HCSR chart, and registry browser.
-- **Optional authentication** powered by NextAuth credentials provider, disabled by default for local development.
+- **Authentication & profiles** powered by NextAuth credentials provider, enabled by default so every environment is scoped per user.
 - **Vitest test suite** covering FIT parsing normalization, HCSR computations, registry wiring, and an API happy-path smoke test.
 - **Docker Compose** for local production-style deployment (Postgres + API + Web) and GitHub Actions CI running lint, typecheck, and tests.
 
@@ -55,9 +55,9 @@ Key variables:
 
 ### Authentication
 
-To activate user authentication end to end:
+Authentication and per-user profiles are now enabled by default. To confirm the end-to-end flow:
 
-1. **Update environment variables** – edit your `.env` (or the respective backend/frontend `.env` files if split) and set:
+1. **Update environment variables** – edit your `.env` (or the respective backend/frontend `.env` files if split) and ensure:
    - `AUTH_ENABLED=true`
    - `NEXT_PUBLIC_AUTH_ENABLED=true`
    - `NEXTAUTH_SECRET=<generate a long random string>`
@@ -71,8 +71,8 @@ To activate user authentication end to end:
    These commands create the `User` and `Profile` tables and seed the metric registry used after login.
 4. **Create an account** – visit `/register` in the web app, sign up with an email and password (minimum 8 characters), then sign in via `/signin`. After authentication you will be redirected to `/profile` to complete your display name, avatar, and bio.
 
-- **Open mode** – leave `AUTH_ENABLED=false` and `NEXT_PUBLIC_AUTH_ENABLED=false` (the defaults) to skip authentication entirely. Uploads, metrics, and activities are shared across visitors which keeps local demos frictionless.
-- **Protected mode** – with the variables above enabled, all new uploads and activity history are automatically scoped to the authenticated user via bearer tokens issued by the backend. API calls to `/upload`, `/activities`, `/profile`, and metric recomputation endpoints require an authenticated session.
+- **Protected mode (default)** – with the variables above enabled, all new uploads and activity history are automatically scoped to the authenticated user via bearer tokens issued by the backend. API calls to `/upload`, `/activities`, `/profile`, and metric recomputation endpoints require an authenticated session.
+- **Open mode** – set `AUTH_ENABLED=false` and `NEXT_PUBLIC_AUTH_ENABLED=false` to skip authentication entirely. Uploads, metrics, and activities are shared across visitors which keeps local demos frictionless.
 
 ### Database
 

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -12,7 +12,7 @@ const envSchema = z.object({
   AUTH_ENABLED: z
     .string()
     .optional()
-    .transform((val) => (val ? val.toLowerCase() === 'true' : false)),
+    .transform((val) => (val ? val.toLowerCase() === 'true' : true)),
   NEXTAUTH_SECRET: z.string().optional(),
   JWT_SECRET: z.string().optional(),
   UPLOAD_DIR: z.string().default('./uploads'),

--- a/apps/backend/tests/setup.ts
+++ b/apps/backend/tests/setup.ts
@@ -6,6 +6,10 @@ if (!process.env.DATABASE_URL) {
   process.env.DATABASE_URL = 'postgres://localhost:5432/test';
 }
 
+if (!process.env.AUTH_ENABLED) {
+  process.env.AUTH_ENABLED = 'true';
+}
+
 if (!process.env.NEXTAUTH_SECRET) {
   process.env.NEXTAUTH_SECRET = 'test-secret';
 }

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -9,7 +9,7 @@ const envSchema = z.object({
   NEXT_PUBLIC_AUTH_ENABLED: z
     .enum(['true', 'false'])
     .optional()
-    .default('false'),
+    .default('true'),
 });
 
 const parsed = envSchema.parse({


### PR DESCRIPTION
## Summary
- default the backend and frontend auth toggles to enabled and document the new behavior
- update the environment example and authentication docs to reflect protected-mode defaults
- adjust backend API tests to exercise authenticated flows and ensure saved activities carry the user id

## Testing
- pnpm --filter backend test

------
https://chatgpt.com/codex/tasks/task_e_68d8e56b72b483308a5c561d3262cace