### PR TITLE
Add moving averages analytics page

### DIFF
--- a/apps/backend/src/metrics/normalizedPower.ts
+++ b/apps/backend/src/metrics/normalizedPower.ts
@@ -1,5 +1,6 @@
-import type { MetricModule, MetricSample } from './types.js';
 import { computeAveragePower, computeNormalizedPower, extractPowerSamples } from '../utils/power.js';
+
+import type { MetricModule } from './types.js';
 
 const WINDOW_SECONDS = 30;
 const COASTING_THRESHOLD_WATTS = 5;

--- a/apps/backend/src/routes/metrics.ts
+++ b/apps/backend/src/routes/metrics.ts
@@ -6,6 +6,7 @@ import { prisma } from '../prisma.js';
 import { normalizeIntervalEfficiencySeries } from '../metrics/intervalEfficiency.js';
 import { logger } from '../logger.js';
 import { computeAdaptationEdges } from '../services/adaptationEdgesService.js';
+import { computeMovingAverageInputs } from '../services/movingAveragesService.js';
 
 type IntervalEfficiencyHistoryRow = {
   activityId: string;
@@ -155,6 +156,20 @@ metricsRouter.get(
       res.json(analysis);
     } catch (error) {
       logger.error({ err: error }, 'Failed to compute adaptation edges');
+      throw error;
+    }
+  }),
+);
+
+metricsRouter.get(
+  '/moving-averages',
+  asyncHandler(async (req, res) => {
+    try {
+      const userId = req.user?.id;
+      const days = await computeMovingAverageInputs(userId);
+      res.json({ days });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to compute moving averages');
       throw error;
     }
   }),

--- a/apps/backend/src/services/movingAveragesService.ts
+++ b/apps/backend/src/services/movingAveragesService.ts
@@ -1,0 +1,199 @@
+import { prisma } from '../prisma.js';
+import type { MetricSample } from '../metrics/types.js';
+import {
+  computeBestRollingAverage,
+  extractPowerSamples,
+  sumPower,
+} from '../utils/power.js';
+
+const POWER_DURATIONS_SECONDS = [60, 300, 1200, 3600] as const;
+
+type PowerDurationKey = `${(typeof POWER_DURATIONS_SECONDS)[number]}`;
+
+interface ActivityRecord {
+  id: string;
+  startTime: Date;
+  sampleRateHz: number | null;
+}
+
+interface DayAggregation {
+  date: Date;
+  totalKj: number;
+  bestPower: Map<PowerDurationKey, number | null>;
+}
+
+export interface MovingAverageDay {
+  date: string;
+  totalKj: number;
+  bestPower: Record<PowerDurationKey, number | null>;
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function toUtcStartOfDay(date: Date): Date {
+  const start = new Date(date);
+  start.setUTCHours(0, 0, 0, 0);
+  return start;
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  const copy = new Date(date);
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+
+function initializeBestPowerMap(): Map<PowerDurationKey, number | null> {
+  const map = new Map<PowerDurationKey, number | null>();
+  for (const duration of POWER_DURATIONS_SECONDS) {
+    map.set(String(duration) as PowerDurationKey, null);
+  }
+  return map;
+}
+
+function computeSampleRate(activity: ActivityRecord): number {
+  if (activity.sampleRateHz && activity.sampleRateHz > 0) {
+    return activity.sampleRateHz;
+  }
+  return 1;
+}
+
+function mergeDayAggregation(
+  map: Map<string, DayAggregation>,
+  activity: ActivityRecord,
+  samples: MetricSample[],
+) {
+  const powerSamples = extractPowerSamples(samples);
+  const sampleRate = computeSampleRate(activity);
+  const totalJoules = sumPower(samples);
+  const totalKj = totalJoules / 1000;
+
+  const dayKey = toDateKey(activity.startTime);
+  const startOfDay = toUtcStartOfDay(activity.startTime);
+
+  const existing = map.get(dayKey);
+  const bestPower = existing?.bestPower ?? initializeBestPowerMap();
+
+  for (const duration of POWER_DURATIONS_SECONDS) {
+    const windowSize = Math.max(1, Math.round(duration * sampleRate));
+    const best = computeBestRollingAverage(powerSamples, windowSize);
+    const key = String(duration) as PowerDurationKey;
+    if (best != null && Number.isFinite(best)) {
+      const rounded = Number.parseFloat(best.toFixed(1));
+      const current = bestPower.get(key);
+      if (current == null || rounded > current) {
+        bestPower.set(key, rounded);
+      }
+    }
+  }
+
+  if (existing) {
+    existing.totalKj += totalKj;
+    return;
+  }
+
+  map.set(dayKey, {
+    date: startOfDay,
+    totalKj,
+    bestPower,
+  });
+}
+
+function buildTimeline(dayMap: Map<string, DayAggregation>): DayAggregation[] {
+  const keys = Array.from(dayMap.keys()).sort();
+  if (keys.length === 0) {
+    return [];
+  }
+
+  const timeline: DayAggregation[] = [];
+  let cursor = toUtcStartOfDay(new Date(`${keys[0]}T00:00:00.000Z`));
+  const end = toUtcStartOfDay(new Date(`${keys[keys.length - 1]}T00:00:00.000Z`));
+
+  while (cursor.getTime() <= end.getTime()) {
+    const key = toDateKey(cursor);
+    const entry = dayMap.get(key);
+    if (entry) {
+      timeline.push({
+        date: entry.date,
+        totalKj: entry.totalKj,
+        bestPower: new Map(entry.bestPower),
+      });
+    } else {
+      timeline.push({
+        date: new Date(cursor),
+        totalKj: 0,
+        bestPower: initializeBestPowerMap(),
+      });
+    }
+    cursor = addUtcDays(cursor, 1);
+  }
+
+  return timeline;
+}
+
+function serializeDay(entry: DayAggregation): MovingAverageDay {
+  const bestPower: Record<PowerDurationKey, number | null> = {
+    '60': entry.bestPower.get('60') ?? null,
+    '300': entry.bestPower.get('300') ?? null,
+    '1200': entry.bestPower.get('1200') ?? null,
+    '3600': entry.bestPower.get('3600') ?? null,
+  };
+
+  return {
+    date: entry.date.toISOString(),
+    totalKj: Number.parseFloat(entry.totalKj.toFixed(2)),
+    bestPower,
+  };
+}
+
+export async function computeMovingAverageInputs(userId?: string): Promise<MovingAverageDay[]> {
+  const activities = await prisma.activity.findMany({
+    where: userId ? { userId } : undefined,
+    orderBy: { startTime: 'asc' },
+    select: {
+      id: true,
+      startTime: true,
+      sampleRateHz: true,
+    },
+  });
+
+  if (activities.length === 0) {
+    return [];
+  }
+
+  const samplesByActivity = new Map<string, MetricSample[]>();
+  await Promise.all(
+    activities.map(async (activity) => {
+      const rows = await prisma.activitySample.findMany({
+        where: { activityId: activity.id },
+        orderBy: { t: 'asc' },
+        select: {
+          t: true,
+          power: true,
+        },
+      });
+
+      const mapped = rows.map((row) => ({
+        t: row.t,
+        power: row.power ?? null,
+        heartRate: null,
+        cadence: null,
+        speed: null,
+        elevation: null,
+        temperature: null,
+      }));
+
+      samplesByActivity.set(activity.id, mapped);
+    }),
+  );
+
+  const dayMap = new Map<string, DayAggregation>();
+  for (const activity of activities) {
+    const samples = samplesByActivity.get(activity.id) ?? [];
+    mergeDayAggregation(dayMap, activity, samples);
+  }
+
+  const timeline = buildTimeline(dayMap);
+  return timeline.map(serializeDay);
+}

--- a/apps/web/app/moving-averages/page.tsx
+++ b/apps/web/app/moving-averages/page.tsx
@@ -1,0 +1,59 @@
+import { redirect } from 'next/navigation';
+
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
+import { MovingAverageCharts } from '../../components/moving-average-charts';
+import { getServerAuthSession } from '../../lib/auth';
+import { env } from '../../lib/env';
+import type { MovingAveragesResponse } from '../../types/moving-averages';
+
+async function getMovingAverageData(token?: string): Promise<MovingAveragesResponse> {
+  const headers: HeadersInit | undefined = token ? { Authorization: `Bearer ${token}` } : undefined;
+  try {
+    const response = await fetch(`${env.internalApiUrl}/metrics/moving-averages`, {
+      cache: 'no-store',
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to load moving averages');
+    }
+
+    return (await response.json()) as MovingAveragesResponse;
+  } catch (error) {
+    console.error('Failed to load moving averages', error);
+    return { days: [] };
+  }
+}
+
+export default async function MovingAveragesPage() {
+  const session = await getServerAuthSession();
+  if (env.authEnabled && !session) {
+    redirect('/signin');
+  }
+
+  const data = await getMovingAverageData(session?.accessToken);
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Moving averages</h1>
+        <p className="text-muted-foreground">
+          Visualize how your training load and power durability evolve across multi-month rolling
+          windows.
+        </p>
+      </div>
+
+      {data.days.length === 0 ? (
+        <Alert>
+          <AlertTitle>No activities yet</AlertTitle>
+          <AlertDescription>
+            Upload a FIT file and compute metrics to unlock long-term moving averages for energy and
+            peak power.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <MovingAverageCharts days={data.days} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/moving-average-charts.tsx
+++ b/apps/web/components/moving-average-charts.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { MovingAverageDay, PeakPowerDurationKey } from '../types/moving-averages';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+
+const DAILY_KJ_WINDOWS = [
+  { windowDays: 45, label: '45-day' },
+  { windowDays: 90, label: '90-day' },
+  { windowDays: 180, label: '180-day' },
+  { windowDays: 365, label: '1-year' },
+  { windowDays: 730, label: '2-year' },
+  { windowDays: 1095, label: '3-year' },
+] as const;
+
+const POWER_DURATIONS: Array<{ key: PeakPowerDurationKey; label: string }> = [
+  { key: '60', label: '1-minute' },
+  { key: '300', label: '5-minute' },
+  { key: '1200', label: '20-minute' },
+  { key: '3600', label: '60-minute' },
+];
+
+const POWER_MOVING_AVERAGE_WINDOW = 45;
+
+const KJ_COLORS = ['#0ea5e9', '#22c55e', '#6366f1', '#f97316', '#9333ea', '#64748b'];
+const POWER_COLORS = ['#ef4444', '#f59e0b', '#10b981', '#6366f1'];
+
+type ChartDatum = { date: number } & Record<string, number | null>;
+
+type RollingAverageOptions = {
+  ignoreNulls?: boolean;
+};
+
+function formatTooltipValue(value: unknown, unit: string): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${value.toFixed(1)} ${unit}`;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isNaN(parsed)) {
+      return `${parsed.toFixed(1)} ${unit}`;
+    }
+  }
+  return '—';
+}
+
+function computeRollingAverage(
+  values: Array<number | null>,
+  windowSize: number,
+  options: RollingAverageOptions = {},
+): Array<number | null> {
+  const { ignoreNulls = false } = options;
+  if (windowSize <= 0) {
+    return values.map(() => null);
+  }
+
+  const result: Array<number | null> = values.map(() => null);
+  const window: Array<number | null> = [];
+  let sum = 0;
+  let nonNullCount = 0;
+
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    window.push(value);
+    sum += value ?? 0;
+    if (value != null) {
+      nonNullCount += 1;
+    }
+
+    if (window.length > windowSize) {
+      const removed = window.shift();
+      sum -= removed ?? 0;
+      if (removed != null) {
+        nonNullCount -= 1;
+      }
+    }
+
+    if (index >= windowSize - 1) {
+      const divisor = ignoreNulls ? nonNullCount : windowSize;
+      if (divisor > 0) {
+        result[index] = Number.parseFloat((sum / divisor).toFixed(1));
+      } else {
+        result[index] = null;
+      }
+    }
+  }
+
+  return result;
+}
+
+interface MovingAverageChartsProps {
+  days: MovingAverageDay[];
+}
+
+export function MovingAverageCharts({ days }: MovingAverageChartsProps) {
+  const sortedDays = useMemo(
+    () =>
+      [...days].sort(
+        (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+      ),
+    [days],
+  );
+
+  const kjChartData = useMemo<ChartDatum[]>(() => {
+    if (sortedDays.length === 0) {
+      return [];
+    }
+    const totals = sortedDays.map((day) => day.totalKj ?? 0);
+    const points: ChartDatum[] = sortedDays.map((day) => ({
+      date: new Date(day.date).getTime(),
+    }));
+
+    DAILY_KJ_WINDOWS.forEach((window) => {
+      const averages = computeRollingAverage(totals, window.windowDays);
+      averages.forEach((value, index) => {
+        points[index][`kj_${window.windowDays}`] = value;
+      });
+    });
+
+    return points;
+  }, [sortedDays]);
+
+  const powerChartData = useMemo<ChartDatum[]>(() => {
+    if (sortedDays.length === 0) {
+      return [];
+    }
+
+    const points: ChartDatum[] = sortedDays.map((day) => ({
+      date: new Date(day.date).getTime(),
+    }));
+
+    POWER_DURATIONS.forEach((duration) => {
+      const series = sortedDays.map((day) => day.bestPower[duration.key] ?? null);
+      const averages = computeRollingAverage(series, POWER_MOVING_AVERAGE_WINDOW, {
+        ignoreNulls: true,
+      });
+      averages.forEach((value, index) => {
+        points[index][`power_${duration.key}`] = value;
+      });
+    });
+
+    return points;
+  }, [sortedDays]);
+
+  const shortDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en', {
+        month: 'short',
+        day: 'numeric',
+      }),
+    [],
+  );
+
+  const fullDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    [],
+  );
+
+  if (sortedDays.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base font-semibold">Daily energy moving averages</CardTitle>
+          <CardDescription>
+            Track how your training load evolves by comparing multi-month rolling averages of
+            kilojoules burned each day.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[360px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={kjChartData} margin={{ left: 12, right: 16, top: 12, bottom: 12 }}>
+              <CartesianGrid strokeDasharray="4 4" stroke="#e2e8f0" />
+              <XAxis
+                dataKey="date"
+                tickFormatter={(value) => shortDateFormatter.format(new Date(value))}
+                type="number"
+                domain={['auto', 'auto']}
+              />
+              <YAxis tickFormatter={(value) => `${value}`} />
+              <Tooltip
+                labelFormatter={(value) => fullDateFormatter.format(new Date(value))}
+                formatter={(value) => [formatTooltipValue(value, 'kJ'), 'Average']}
+              />
+              <Legend />
+              {DAILY_KJ_WINDOWS.map((window, index) => (
+                <Line
+                  key={window.windowDays}
+                  type="monotone"
+                  dataKey={`kj_${window.windowDays}`}
+                  stroke={KJ_COLORS[index % KJ_COLORS.length]}
+                  strokeWidth={2}
+                  dot={false}
+                  name={`${window.label} average`}
+                  isAnimationActive={false}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base font-semibold">Peak power moving averages</CardTitle>
+          <CardDescription>
+            Smooth daily best efforts to monitor long-term trends in your 1, 5, 20, and 60-minute
+            power.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[360px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={powerChartData} margin={{ left: 12, right: 16, top: 12, bottom: 12 }}>
+              <CartesianGrid strokeDasharray="4 4" stroke="#e2e8f0" />
+              <XAxis
+                dataKey="date"
+                tickFormatter={(value) => shortDateFormatter.format(new Date(value))}
+                type="number"
+                domain={['auto', 'auto']}
+              />
+              <YAxis tickFormatter={(value) => `${value}`} />
+              <Tooltip
+                labelFormatter={(value) => fullDateFormatter.format(new Date(value))}
+                formatter={(value) => [formatTooltipValue(value, 'W'), 'Average peak']}
+              />
+              <Legend />
+              {POWER_DURATIONS.map((duration, index) => (
+                <Line
+                  key={duration.key}
+                  type="monotone"
+                  dataKey={`power_${duration.key}`}
+                  stroke={POWER_COLORS[index % POWER_COLORS.length]}
+                  strokeWidth={2}
+                  dot={false}
+                  name={`${duration.label} (45-day)`}
+                  isAnimationActive={false}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -11,6 +11,7 @@ const baseNavItems = [
   { href: '/', label: 'Home' },
   { href: '/activities', label: 'Activities' },
   { href: '/activities/trends', label: 'Trends' },
+  { href: '/moving-averages', label: 'Moving averages' },
   { href: '/metrics', label: 'Metrics' },
 ];
 

--- a/apps/web/types/moving-averages.ts
+++ b/apps/web/types/moving-averages.ts
@@ -1,0 +1,11 @@
+export type PeakPowerDurationKey = '60' | '300' | '1200' | '3600';
+
+export interface MovingAverageDay {
+  date: string;
+  totalKj: number;
+  bestPower: Record<PeakPowerDurationKey, number | null>;
+}
+
+export interface MovingAveragesResponse {
+  days: MovingAverageDay[];
+}


### PR DESCRIPTION
## Summary
- add a backend service and API route to build daily energy and peak power inputs for moving averages
- create a moving averages dashboard page with charts for training load and peak power trends
- expose the page in the site navigation and share types/utilities for the new data

## Testing
- pnpm --filter backend lint
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68d8edf112dc833099b2ca6555705d30