### PR TITLE
Improve duration formatting and add tests

### DIFF
--- a/apps/web/components/activity-detail-client.tsx
+++ b/apps/web/components/activity-detail-client.tsx
@@ -10,6 +10,7 @@ import {
   fetchIntervalEfficiency,
   fetchMetricResult,
 } from '../lib/api';
+import { formatDuration } from '../lib/utils';
 import type {
   ActivitySummary,
   IntervalEfficiencyResponse,
@@ -323,7 +324,7 @@ export function ActivityDetailClient({
         <div>
           <h1 className="text-3xl font-bold">Ride on {new Date(activity.startTime).toLocaleString()}</h1>
           <p className="text-muted-foreground">
-            {activity.source} · duration {Math.round(activity.durationSec / 60)} minutes
+            {activity.source} · duration {formatDuration(activity.durationSec)}
           </p>
         </div>
         <Button onClick={handleRecompute} disabled={isPending} variant="secondary">

--- a/apps/web/lib/utils.test.ts
+++ b/apps/web/lib/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDuration } from './utils';
+
+describe('formatDuration', () => {
+  it('formats durations under a minute using seconds only', () => {
+    expect(formatDuration(0)).toBe('0s');
+    expect(formatDuration(45)).toBe('45s');
+  });
+
+  it('formats minute-level durations with padded seconds', () => {
+    expect(formatDuration(60)).toBe('1m 00s');
+    expect(formatDuration(61)).toBe('1m 01s');
+    expect(formatDuration(125)).toBe('2m 05s');
+  });
+
+  it('formats hour-level durations with padded minutes and seconds', () => {
+    expect(formatDuration(3600)).toBe('1h 00m 00s');
+    expect(formatDuration(3661)).toBe('1h 01m 01s');
+    expect(formatDuration(7322)).toBe('2h 02m 02s');
+  });
+
+  it('rounds fractional seconds and clamps negative values', () => {
+    expect(formatDuration(90.7)).toBe('1m 31s');
+    expect(formatDuration(-42)).toBe('0s');
+  });
+});

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -6,7 +6,27 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatDuration(seconds: number) {
-  const minutes = Math.floor(seconds / 60);
-  const remaining = seconds % 60;
-  return `${minutes}m ${remaining}s`;
+  const totalSeconds = Number.isFinite(seconds) ? Math.max(0, Math.round(seconds)) : 0;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const remainingSeconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+
+  if (hours > 0 || minutes > 0) {
+    const paddedMinutes = hours > 0 ? minutes.toString().padStart(2, '0') : minutes.toString();
+    parts.push(`${paddedMinutes}m`);
+  }
+
+  if (hours > 0 || minutes > 0) {
+    parts.push(`${remainingSeconds.toString().padStart(2, '0')}s`);
+  } else {
+    parts.push(`${remainingSeconds}s`);
+  }
+
+  return parts.join(' ');
 }


### PR DESCRIPTION
## Summary
- enhance the shared `formatDuration` helper to support hour-level output, padding, and invalid input handling
- use the improved formatter on the activity detail header for consistent ride duration messaging
- add Vitest coverage for the formatter to guard against regressions

## Testing
- pnpm --filter web test

------
https://chatgpt.com/codex/tasks/task_e_68d8f1f5f1808330befa23f492a2e05f