### PR TITLE
Expose auth routes at root path

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -3,6 +3,7 @@ import express from 'express';
 
 import { env } from './env.js';
 import { errorHandler, notFound } from './middleware/errorHandler.js';
+import { authRouter } from './routes/auth.js';
 import { apiRouter } from './routes/index.js';
 
 export function createApp() {
@@ -21,6 +22,7 @@ export function createApp() {
     res.json({ status: 'ok' });
   });
 
+  app.use('/auth', authRouter);
   app.use('/api', apiRouter);
 
   app.use(notFound);


### PR DESCRIPTION
## Summary
- mount the backend auth router at `/auth` so registration works when clients omit the `/api` prefix
- keep existing `/api/auth/*` endpoints available for backwards compatibility

## Testing
- pnpm --filter backend test

------
https://chatgpt.com/codex/tasks/task_e_68d900fb573c83309cc8a6d43b55e3f2