### PR TITLE
Add script to backfill metrics across all activities

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate deploy",
-    "seed": "prisma db seed"
+    "seed": "prisma db seed",
+    "backfill:metrics": "tsx src/scripts/backfillMetrics.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.11.0",

--- a/apps/backend/src/scripts/backfillMetrics.ts
+++ b/apps/backend/src/scripts/backfillMetrics.ts
@@ -1,0 +1,32 @@
+import { prisma } from '../prisma.js';
+import { runMetrics } from '../metrics/runner.js';
+
+async function main() {
+  const activities = await prisma.activity.findMany({
+    orderBy: { startTime: 'asc' },
+  });
+
+  const total = activities.length;
+  console.log(`Computing metrics for ${total} activities...`);
+
+  for (let index = 0; index < activities.length; index += 1) {
+    const activity = activities[index];
+    const count = index + 1;
+
+    try {
+      await runMetrics(activity.id);
+      console.log(`[${count}/${total}] computed for ${activity.id}`);
+    } catch (error) {
+      console.error(`[${count}/${total}] failed for ${activity.id}`, error);
+    }
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('Failed to backfill metrics', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add a backfillMetrics script that recomputes metrics for every activity using the existing runner
- log progress and ensure Prisma disconnects after processing
- add an npm script for running the backfill from the command line

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94341d6848330887e7becaedea7dd