### PR TITLE
Add skeleton component for training frontiers view

### DIFF
--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Skeleton = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  ),
+);
+Skeleton.displayName = 'Skeleton';
+
+export { Skeleton };


### PR DESCRIPTION
## Summary
- add a reusable Skeleton component under the UI components directory
- ensure the Skeleton matches existing utility patterns for class name composition

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68dd1e550e3483309b81bc1ea87f34d8