### PR TITLE
Adjust ride map projection for accurate display

### DIFF
--- a/apps/web/components/ride-track-map.tsx
+++ b/apps/web/components/ride-track-map.tsx
@@ -30,13 +30,17 @@ function normalizePoints(points: ActivityTrackPoint[]) {
   }
 
   const latRange = Math.max(maxLat - minLat, 1e-6);
-  const lonRange = Math.max(maxLon - minLon, 1e-6);
+  const midLatitudeRadians = ((maxLat + minLat) / 2) * (Math.PI / 180);
+  // Longitude degrees shrink by cos(latitude); adjust so tracks keep their aspect ratio.
+  const lonToLatRatio = Math.max(Math.abs(Math.cos(midLatitudeRadians)), 1e-6);
+  const lonRange = Math.max((maxLon - minLon) * lonToLatRatio, 1e-6);
   const scale = Math.min(VIEWBOX_WIDTH / lonRange, VIEWBOX_HEIGHT / latRange);
   const offsetX = (VIEWBOX_WIDTH - lonRange * scale) / 2;
   const offsetY = (VIEWBOX_HEIGHT - latRange * scale) / 2;
 
   return points.map((point) => {
-    const x = (point.longitude - minLon) * scale + offsetX;
+    const projectedLon = (point.longitude - minLon) * lonToLatRatio;
+    const x = projectedLon * scale + offsetX;
     const y = VIEWBOX_HEIGHT - ((point.latitude - minLat) * scale + offsetY);
     return [Number.parseFloat(x.toFixed(2)), Number.parseFloat(y.toFixed(2))] as [number, number];
   });


### PR DESCRIPTION
## Summary
- adjust the track normalization to scale longitudes by cosine(latitude)
- keep the rendered ride path aspect ratio closer to the recorded GPS track

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68df2a46c6f083308e6d54de32d14c82