### PR TITLE
Refine metrics navigation structure

### DIFF
--- a/apps/web/app/metrics/(tabs)/adaptation/page.tsx
+++ b/apps/web/app/metrics/(tabs)/adaptation/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation';
+
+import { AdaptationDeepestBlocks } from '../../../../components/adaptation-deepest-blocks';
+import { Alert, AlertDescription, AlertTitle } from '../../../../components/ui/alert';
+import { getServerAuthSession } from '../../../../lib/auth';
+import { env } from '../../../../lib/env';
+import { fetchAdaptationEdges } from '../shared';
+
+export default async function AdaptationPage() {
+  const session = await getServerAuthSession();
+  if (env.authEnabled && !session) {
+    redirect('/signin');
+  }
+
+  try {
+    const adaptation = await fetchAdaptationEdges(session?.accessToken);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold">Adaptation edges</h1>
+          <p className="text-muted-foreground">
+            Surface your deepest training blocks and understand how efficiency evolved across each block. Use
+            these summaries to plan when to extend or reload your next progression.
+          </p>
+        </div>
+        <AdaptationDeepestBlocks analysis={adaptation} />
+      </div>
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error while fetching adaptation edges.';
+
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Unable to load adaptation edges</AlertTitle>
+        <AlertDescription>
+          {message}. Ensure the backend API is running and the adaptation edges endpoint is available{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">pnpm seed</code>.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+}

--- a/apps/web/app/metrics/(tabs)/interval-efficiency/page.tsx
+++ b/apps/web/app/metrics/(tabs)/interval-efficiency/page.tsx
@@ -1,0 +1,111 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+
+import { IntervalEfficiencyHistoryChart } from '../../../../components/interval-efficiency-history-chart';
+import { Alert, AlertDescription, AlertTitle } from '../../../../components/ui/alert';
+import { Card, CardContent, CardHeader, CardTitle } from '../../../../components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../../components/ui/table';
+import { getServerAuthSession } from '../../../../lib/auth';
+import { env } from '../../../../lib/env';
+import { fetchIntervalEfficiencyHistory } from '../shared';
+
+export default async function IntervalEfficiencyPage() {
+  const session = await getServerAuthSession();
+  if (env.authEnabled && !session) {
+    redirect('/signin');
+  }
+
+  try {
+    const history = await fetchIntervalEfficiencyHistory(session?.accessToken);
+
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold">Interval efficiency</h1>
+          <p className="text-muted-foreground">
+            Compare watts-per-heart-rate efficiency across your rides to spot adaptation or fatigue trends.
+            Use the ride table to jump directly into detailed activity summaries when something stands out.
+          </p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-semibold">
+              {history.metric.name}{' '}
+              <span className="text-xs text-muted-foreground">({history.metric.units ?? 'unitless'})</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <IntervalEfficiencyHistoryChart points={history.points} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-semibold">Activity comparison</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Start time</TableHead>
+                  <TableHead>Intervals</TableHead>
+                  <TableHead>Avg W/HR</TableHead>
+                  <TableHead>First interval</TableHead>
+                  <TableHead>Last interval</TableHead>
+                  <TableHead className="text-right">View</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.points.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-6 text-center text-sm text-muted-foreground">
+                      No interval efficiency metrics computed yet. Upload and compute metrics to populate this
+                      view.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  history.points.map((point) => {
+                    const formattedStart = new Date(point.activityStartTime).toLocaleString();
+
+                    return (
+                      <TableRow key={point.activityId}>
+                        <TableCell className="font-medium">{formattedStart}</TableCell>
+                        <TableCell>{point.intervalCount}</TableCell>
+                        <TableCell>
+                          {point.averageWPerHr != null ? point.averageWPerHr.toFixed(2) : '—'}
+                        </TableCell>
+                        <TableCell>
+                          {point.firstIntervalWPerHr != null ? point.firstIntervalWPerHr.toFixed(2) : '—'}
+                        </TableCell>
+                        <TableCell>
+                          {point.lastIntervalWPerHr != null ? point.lastIntervalWPerHr.toFixed(2) : '—'}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Link className="text-primary underline" href={`/activities/${point.activityId}`}>
+                            Activity
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown error while fetching interval efficiency history.';
+
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Unable to load interval efficiency</AlertTitle>
+        <AlertDescription>
+          {message}. Ensure the backend API is running and the metrics have been computed{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">pnpm seed</code>.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+}

--- a/apps/web/app/metrics/(tabs)/registry/page.tsx
+++ b/apps/web/app/metrics/(tabs)/registry/page.tsx
@@ -1,68 +1,13 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
+import { MetricsDefinitionBrowser } from '../../../../components/metrics-definition-browser';
+import { Button } from '../../../../components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '../../../../components/ui/alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../../../components/ui/card';
 import { getServerAuthSession } from '../../../../lib/auth';
 import { env } from '../../../../lib/env';
-import type {
-  IntervalEfficiencyHistoryResponse,
-  MetricDefinition,
-} from '../../../../types/activity';
-import type { AdaptationEdgesResponse } from '../../../../types/adaptation';
-import { AdaptationDeepestBlocks } from '../../../../components/adaptation-deepest-blocks';
-import { IntervalEfficiencyHistoryChart } from '../../../../components/interval-efficiency-history-chart';
-import { MetricsDefinitionBrowser } from '../../../../components/metrics-definition-browser';
-import { Alert, AlertDescription, AlertTitle } from '../../../../components/ui/alert';
-import { Card, CardContent, CardHeader, CardTitle } from '../../../../components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../../components/ui/table';
-
-async function getMetricDefinitions(token?: string): Promise<MetricDefinition[]> {
-  const headers: HeadersInit | undefined = token
-    ? { Authorization: `Bearer ${token}` }
-    : undefined;
-  const response = await fetch(`${env.internalApiUrl}/metrics`, {
-    cache: 'no-store',
-    headers,
-  });
-  if (!response.ok) {
-    throw new Error('Failed to load metric definitions');
-  }
-  const data = (await response.json()) as { definitions: MetricDefinition[] };
-  return data.definitions;
-}
-
-async function getIntervalEfficiencyHistory(
-  token?: string,
-): Promise<IntervalEfficiencyHistoryResponse> {
-  const headers: HeadersInit | undefined = token
-    ? { Authorization: `Bearer ${token}` }
-    : undefined;
-  const response = await fetch(`${env.internalApiUrl}/metrics/interval-efficiency/history`, {
-    cache: 'no-store',
-    headers,
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to load interval efficiency history');
-  }
-
-  return (await response.json()) as IntervalEfficiencyHistoryResponse;
-}
-
-async function getAdaptationEdges(token?: string): Promise<AdaptationEdgesResponse> {
-  const headers: HeadersInit | undefined = token
-    ? { Authorization: `Bearer ${token}` }
-    : undefined;
-  const response = await fetch(`${env.internalApiUrl}/metrics/adaptation-edges/deepest-blocks`, {
-    cache: 'no-store',
-    headers,
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to load adaptation edges');
-  }
-
-  return (await response.json()) as AdaptationEdgesResponse;
-}
+import { fetchMetricDefinitions } from '../shared';
 
 export default async function MetricsPage() {
   const session = await getServerAuthSession();
@@ -71,11 +16,7 @@ export default async function MetricsPage() {
   }
 
   try {
-    const [definitions, history, adaptationEdges] = await Promise.all([
-      getMetricDefinitions(session?.accessToken),
-      getIntervalEfficiencyHistory(session?.accessToken),
-      getAdaptationEdges(session?.accessToken),
-    ]);
+    const definitions = await fetchMetricDefinitions(session?.accessToken);
 
     return (
       <div className="space-y-8">
@@ -87,90 +28,34 @@ export default async function MetricsPage() {
           </p>
         </div>
         <MetricsDefinitionBrowser definitions={definitions} />
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <h2 className="text-2xl font-semibold">Interval efficiency trends</h2>
-            <p className="text-sm text-muted-foreground">
-              Compare watts-per-heart-rate efficiency across your rides to identify improvements or
-              fatigue over time.
-            </p>
-          </div>
+        <div className="grid gap-4 md:grid-cols-2">
           <Card>
             <CardHeader>
-              <CardTitle className="text-base font-semibold">
-                {history.metric.name}{' '}
-                <span className="text-xs text-muted-foreground">
-                  ({history.metric.units ?? 'unitless'})
-                </span>
-              </CardTitle>
+              <CardTitle className="text-base font-semibold">Interval efficiency trends</CardTitle>
+              <CardDescription>
+                Compare watts-per-heart-rate efficiency across your rides and dig into ride level context.
+              </CardDescription>
             </CardHeader>
-            <CardContent>
-              <IntervalEfficiencyHistoryChart points={history.points} />
+            <CardContent className="pt-0">
+              <Button asChild className="w-full">
+                <Link href="/metrics/interval-efficiency">Open interval efficiency</Link>
+              </Button>
             </CardContent>
           </Card>
           <Card>
             <CardHeader>
-              <CardTitle className="text-base font-semibold">Activity comparison</CardTitle>
+              <CardTitle className="text-base font-semibold">Adaptation edges</CardTitle>
+              <CardDescription>
+                Review your deepest training blocks and how your efficiency evolved across each progression.
+              </CardDescription>
             </CardHeader>
-            <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Start time</TableHead>
-                    <TableHead>Intervals</TableHead>
-                    <TableHead>Avg W/HR</TableHead>
-                    <TableHead>First interval</TableHead>
-                    <TableHead>Last interval</TableHead>
-                    <TableHead className="text-right">View</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {history.points.length === 0 ? (
-                    <TableRow>
-                      <TableCell
-                        colSpan={6}
-                        className="py-6 text-center text-sm text-muted-foreground"
-                      >
-                        No interval efficiency metrics computed yet. Upload and compute metrics to
-                        populate this view.
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    history.points.map((point) => {
-                      const formattedStart = new Date(point.activityStartTime).toLocaleString();
-
-                      return (
-                        <TableRow key={point.activityId}>
-                          <TableCell className="font-medium">{formattedStart}</TableCell>
-                          <TableCell>{point.intervalCount}</TableCell>
-                          <TableCell>
-                            {point.averageWPerHr != null ? point.averageWPerHr.toFixed(2) : '—'}
-                          </TableCell>
-                          <TableCell>
-                            {point.firstIntervalWPerHr != null
-                              ? point.firstIntervalWPerHr.toFixed(2)
-                              : '—'}
-                          </TableCell>
-                          <TableCell>
-                            {point.lastIntervalWPerHr != null
-                              ? point.lastIntervalWPerHr.toFixed(2)
-                              : '—'}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <Link className="text-primary underline" href={`/activities/${point.activityId}`}>
-                              Activity
-                            </Link>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })
-                  )}
-                </TableBody>
-              </Table>
+            <CardContent className="pt-0">
+              <Button asChild className="w-full">
+                <Link href="/metrics/adaptation">View adaptation analysis</Link>
+              </Button>
             </CardContent>
           </Card>
         </div>
-        <AdaptationDeepestBlocks analysis={adaptationEdges} />
       </div>
     );
   } catch (error) {

--- a/apps/web/app/metrics/(tabs)/shared.ts
+++ b/apps/web/app/metrics/(tabs)/shared.ts
@@ -1,0 +1,43 @@
+import type { IntervalEfficiencyHistoryResponse, MetricDefinition } from '../../../types/activity';
+import type { AdaptationEdgesResponse } from '../../../types/adaptation';
+import { env } from '../../../lib/env';
+
+async function fetchWithAuth(path: string, token?: string, errorMessage?: string) {
+  const headers: HeadersInit | undefined = token ? { Authorization: `Bearer ${token}` } : undefined;
+  const response = await fetch(`${env.internalApiUrl}${path}`, {
+    cache: 'no-store',
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new Error(errorMessage ?? `Failed to load ${path}`);
+  }
+
+  return response;
+}
+
+export async function fetchMetricDefinitions(token?: string): Promise<MetricDefinition[]> {
+  const response = await fetchWithAuth('/metrics', token, 'Failed to load metric definitions');
+  const data = (await response.json()) as { definitions: MetricDefinition[] };
+  return data.definitions;
+}
+
+export async function fetchIntervalEfficiencyHistory(
+  token?: string,
+): Promise<IntervalEfficiencyHistoryResponse> {
+  const response = await fetchWithAuth(
+    '/metrics/interval-efficiency/history',
+    token,
+    'Failed to load interval efficiency history',
+  );
+  return (await response.json()) as IntervalEfficiencyHistoryResponse;
+}
+
+export async function fetchAdaptationEdges(token?: string): Promise<AdaptationEdgesResponse> {
+  const response = await fetchWithAuth(
+    '/metrics/adaptation-edges/deepest-blocks',
+    token,
+    'Failed to load adaptation edges',
+  );
+  return (await response.json()) as AdaptationEdgesResponse;
+}

--- a/apps/web/components/metric-tabs-nav.tsx
+++ b/apps/web/components/metric-tabs-nav.tsx
@@ -7,6 +7,8 @@ import { cn } from '../lib/utils';
 
 const tabs = [
   { href: '/metrics/registry', label: 'Registry' },
+  { href: '/metrics/interval-efficiency', label: 'Interval efficiency' },
+  { href: '/metrics/adaptation', label: 'Adaptation edges' },
   { href: '/metrics/kj-in-interval', label: 'KJ in interval' },
   { href: '/metrics/depth-analysis', label: 'Depth analysis' },
 ];


### PR DESCRIPTION
## Summary
- extract interval efficiency and adaptation edges content into dedicated metric sub-pages
- add shared API helpers and expand the metrics tab navigation to surface the new routes
- leave the registry focused on definitions while linking out to the detailed analyses

## Testing
- pnpm lint
- pnpm typecheck *(fails: existing type errors in durability analysis, hcsr chart, and training frontiers components)*

------
https://chatgpt.com/codex/tasks/task_e_68e07b903bdc83308b77b1a50b58f15d