### PR TITLE
Fix ride track serialization for map display

### DIFF
--- a/apps/backend/src/routes/activities.ts
+++ b/apps/backend/src/routes/activities.ts
@@ -166,10 +166,24 @@ activitiesRouter.get(
     const trackPoints = samples
       .map((sample) => {
         const { latitude, longitude } = sample;
-        if (typeof latitude !== 'number' || typeof longitude !== 'number') {
+        const lat =
+          typeof latitude === 'number'
+            ? latitude
+            : latitude != null
+              ? Number(latitude)
+              : null;
+        const lon =
+          typeof longitude === 'number'
+            ? longitude
+            : longitude != null
+              ? Number(longitude)
+              : null;
+
+        if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
           return null;
         }
-        return { latitude, longitude } as TrackPoint;
+
+        return { latitude: lat, longitude: lon } as TrackPoint;
       })
       .filter((point): point is TrackPoint => point !== null);
 


### PR DESCRIPTION
## Summary
- coerce latitude and longitude values from the activity track endpoint into numbers before filtering
- continue excluding invalid coordinates so the ride map receives clean numeric points

## Testing
- pnpm --filter backend test

------
https://chatgpt.com/codex/tasks/task_e_68e08352dd1c833098f32caf7b51a59c