### PR TITLE
Fix ride map rendering when GPS points contain invalid values

### DIFF
--- a/apps/web/components/ride-track-map.tsx
+++ b/apps/web/components/ride-track-map.tsx
@@ -13,7 +13,11 @@ const VIEWBOX_WIDTH = 800;
 const VIEWBOX_HEIGHT = 600;
 
 function normalizePoints(points: ActivityTrackPoint[]) {
-  if (points.length === 0) {
+  const sanitized = points.filter(
+    (point) => Number.isFinite(point.latitude) && Number.isFinite(point.longitude),
+  );
+
+  if (sanitized.length === 0) {
     return [] as Array<[number, number]>;
   }
 
@@ -22,7 +26,7 @@ function normalizePoints(points: ActivityTrackPoint[]) {
   let minLon = Number.POSITIVE_INFINITY;
   let maxLon = Number.NEGATIVE_INFINITY;
 
-  for (const point of points) {
+  for (const point of sanitized) {
     minLat = Math.min(minLat, point.latitude);
     maxLat = Math.max(maxLat, point.latitude);
     minLon = Math.min(minLon, point.longitude);
@@ -38,7 +42,7 @@ function normalizePoints(points: ActivityTrackPoint[]) {
   const offsetX = (VIEWBOX_WIDTH - lonRange * scale) / 2;
   const offsetY = (VIEWBOX_HEIGHT - latRange * scale) / 2;
 
-  return points.map((point) => {
+  return sanitized.map((point) => {
     const projectedLon = (point.longitude - minLon) * lonToLatRatio;
     const x = projectedLon * scale + offsetX;
     const y = VIEWBOX_HEIGHT - ((point.latitude - minLat) * scale + offsetY);


### PR DESCRIPTION
## Summary
- ignore non-finite latitude and longitude values before normalizing ride track points
- keep the map rendering stable even when GPS samples include corrupt data

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68e0a7d4d1d483309285ea62a90fbbda