### PR TITLE
Add safe pathname hook for navigation components

### DIFF
--- a/apps/web/components/metric-tabs-nav.tsx
+++ b/apps/web/components/metric-tabs-nav.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 
 import { cn } from '../lib/utils';
+import { useSafePathname } from '../hooks/use-safe-pathname';
 
 const tabs = [
   { href: '/metrics/registry', label: 'Registry' },
@@ -14,7 +14,7 @@ const tabs = [
 ];
 
 export function MetricTabsNav() {
-  const pathname = usePathname();
+  const pathname = useSafePathname();
 
   return (
     <nav className="flex flex-wrap gap-2">

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { signIn, signOut, useSession } from 'next-auth/react';
 
 import { env } from '../lib/env';
 import { cn } from '../lib/utils';
+import { useSafePathname } from '../hooks/use-safe-pathname';
 import { Button } from './ui/button';
 
 type NavItem = {
@@ -57,7 +57,7 @@ function AuthControls() {
 }
 
 export function SiteHeader() {
-  const pathname = usePathname();
+  const pathname = useSafePathname();
   const { status } = useSession();
 
   const navItems: NavItem[] =

--- a/apps/web/hooks/use-safe-pathname.ts
+++ b/apps/web/hooks/use-safe-pathname.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname as useNextPathname } from 'next/navigation';
+
+function getWindowPathname() {
+  if (typeof window === 'undefined') {
+    return '/';
+  }
+
+  try {
+    return window.location.pathname || '/';
+  } catch (error) {
+    return '/';
+  }
+}
+
+export function useSafePathname(): string {
+  let pathnameFromNext: string | null = null;
+
+  try {
+    pathnameFromNext = useNextPathname();
+  } catch (error) {
+    pathnameFromNext = null;
+  }
+
+  const [fallbackPathname, setFallbackPathname] = useState<string>(() => getWindowPathname());
+
+  const originalsRef = useRef<{
+    pushState: History['pushState'];
+    replaceState: History['replaceState'];
+  } | null>(null);
+
+  useEffect(() => {
+    if (pathnameFromNext !== null) {
+      setFallbackPathname(pathnameFromNext);
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleNavigation = () => {
+      setFallbackPathname(getWindowPathname());
+    };
+
+    handleNavigation();
+
+    window.addEventListener('popstate', handleNavigation);
+
+    if (!originalsRef.current) {
+      originalsRef.current = {
+        pushState: window.history.pushState.bind(window.history),
+        replaceState: window.history.replaceState.bind(window.history),
+      };
+    }
+
+    const { pushState, replaceState } = originalsRef.current;
+
+    const wrapHistoryMethod = <Method extends (...methodArgs: any[]) => void>(original: Method) => {
+      return function wrappedHistoryMethod(this: History, ...args: Parameters<Method>) {
+        original.apply(this, args);
+        handleNavigation();
+      };
+    };
+
+    window.history.pushState = wrapHistoryMethod(pushState);
+    window.history.replaceState = wrapHistoryMethod(replaceState);
+
+    return () => {
+      window.removeEventListener('popstate', handleNavigation);
+
+      window.history.pushState = pushState;
+      window.history.replaceState = replaceState;
+    };
+  }, [pathnameFromNext]);
+
+  return useMemo(() => pathnameFromNext ?? fallbackPathname, [pathnameFromNext, fallbackPathname]);
+}


### PR DESCRIPTION
## Summary
- add a reusable hook that falls back to window history when `usePathname` is unavailable
- update the site header and metric tabs navigation to rely on the new safe pathname helper

## Testing
- pnpm --filter web lint
- pnpm --filter web test
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0bbb893008330b453ae034b398509