### PR TITLE
Add dedicated achievements page and navigation link

### DIFF
--- a/apps/web/app/achievements/page.tsx
+++ b/apps/web/app/achievements/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next';
+
+import { AchievementSection } from '../../components/achievement-section';
+
+export const metadata: Metadata = {
+  title: 'Achievements | Cycling Custom Metrics',
+  description:
+    'Track cycling milestones across climbing, durability, and freshness with the Cycling Custom Metrics achievement tracker.',
+};
+
+export default function AchievementsPage() {
+  return (
+    <div className="space-y-12">
+      <section className="relative overflow-hidden rounded-3xl border bg-card/70 p-8 shadow-lg shadow-primary/10 backdrop-blur md:p-12">
+        <div className="pointer-events-none absolute inset-y-0 left-1/2 -z-10 hidden h-full w-[600px] -translate-x-1/2 rounded-full bg-primary/15 blur-3xl md:block" />
+        <div className="space-y-6">
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+            Achievement hub
+          </div>
+          <div className="space-y-4">
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">Celebrate standout efforts</h1>
+            <p className="text-base text-muted-foreground sm:text-lg">
+              Use the categories below to understand the milestones our analytics highlight. Whether you are chasing vert-heavy adventures or defending freshness for race day, you&apos;ll find the next target here.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <AchievementSection className="shadow-lg shadow-primary/5" />
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,21 +1,9 @@
 import Link from 'next/link';
 
-import {
-  Activity,
-  BarChart3,
-  BrainCircuit,
-  Gauge,
-  Layers3,
-  Leaf,
-  Mountain,
-  Quote,
-  Route,
-  ShieldCheck,
-  Sparkles,
-  Timer,
-} from 'lucide-react';
+import { Activity, BarChart3, BrainCircuit, Gauge, Layers3, Quote, Route, Sparkles, Timer } from 'lucide-react';
 
 import { LandingUpload } from '../components/landing-upload';
+import { AchievementSection } from '../components/achievement-section';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 
@@ -91,46 +79,6 @@ const workspaceSections = [
     description: 'Understand every computed metric and enable new calculations for upcoming rides.',
     href: '/metrics/registry',
     action: 'Browse metrics',
-  },
-];
-
-const achievementCategories = [
-  {
-    title: 'Climbing',
-    description: 'Benchmark vertical strength with elevation-focused challenges.',
-    icon: Mountain,
-    achievements: [
-      {
-        name: 'Summit seeker',
-        detail: 'Complete a ride with over 1,000 meters of elevation gain.',
-      },
-    ],
-  },
-  {
-    title: 'Durability',
-    description: 'Stress-test fatigue resistance during long endurance days.',
-    icon: ShieldCheck,
-    achievements: [
-      {
-        name: 'FTP endurance',
-        detail: 'Hold 90% of FTP for an hour after accumulating three hours of Zone 2 kilojoules.',
-      },
-      {
-        name: 'VO2 staying power',
-        detail: 'Hold 90% of your five-minute power best after three hours of Zone 2 kilojoules.',
-      },
-    ],
-  },
-  {
-    title: 'With Freshness',
-    description: 'Track top-end execution when legs are recharged and ready.',
-    icon: Leaf,
-    achievements: [
-      {
-        name: 'Fresh legs framework',
-        detail: 'We will add freshness-focused achievements soon—this category is built to expand.',
-      },
-    ],
   },
 ];
 
@@ -235,47 +183,7 @@ export default function HomePage() {
         ))}
       </section>
 
-      <section className="space-y-8 rounded-3xl border bg-background/70 p-8 shadow-inner shadow-primary/10 md:p-12">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div className="space-y-3">
-            <h2 className="text-2xl font-semibold tracking-tight text-foreground">Achievement tracker</h2>
-            <p className="text-sm text-muted-foreground">
-              Celebrate standout efforts across climbing, durability, and freshness. Achievements refresh every six months so
-              riders always have new benchmarks to chase.
-            </p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-primary">
-            6-month reset
-          </div>
-        </div>
-        <div className="grid gap-6 md:grid-cols-3">
-          {achievementCategories.map((category) => (
-            <Card key={category.title} className="h-full border-primary/15 bg-background/80">
-              <CardHeader className="space-y-4">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
-                    <category.icon className="h-5 w-5" aria-hidden />
-                  </div>
-                  <div>
-                    <CardTitle className="text-lg font-semibold text-foreground">{category.title}</CardTitle>
-                    <CardDescription>{category.description}</CardDescription>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-3 text-sm text-muted-foreground">
-                  {category.achievements.map((achievement) => (
-                    <li key={achievement.name} className="rounded-xl border border-primary/10 bg-background/90 p-3">
-                      <p className="text-sm font-semibold text-foreground">{achievement.name}</p>
-                      <p className="text-xs text-muted-foreground">{achievement.detail}</p>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </section>
+      <AchievementSection />
 
       <section className="rounded-3xl border bg-background/70 p-8 shadow-inner shadow-primary/10 md:p-12">
         <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">

--- a/apps/web/components/achievement-section.tsx
+++ b/apps/web/components/achievement-section.tsx
@@ -1,0 +1,99 @@
+import { Leaf, Mountain, ShieldCheck } from 'lucide-react';
+
+import { cn } from '../lib/utils';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+
+export const achievementCategories = [
+  {
+    title: 'Climbing',
+    description: 'Benchmark vertical strength with elevation-focused challenges.',
+    icon: Mountain,
+    achievements: [
+      {
+        name: 'Summit seeker',
+        detail: 'Complete a ride with over 1,000 meters of elevation gain.',
+      },
+    ],
+  },
+  {
+    title: 'Durability',
+    description: 'Stress-test fatigue resistance during long endurance days.',
+    icon: ShieldCheck,
+    achievements: [
+      {
+        name: 'FTP endurance',
+        detail: 'Hold 90% of FTP for an hour after accumulating three hours of Zone 2 kilojoules.',
+      },
+      {
+        name: 'VO2 staying power',
+        detail: 'Hold 90% of your five-minute power best after three hours of Zone 2 kilojoules.',
+      },
+    ],
+  },
+  {
+    title: 'With Freshness',
+    description: 'Track top-end execution when legs are recharged and ready.',
+    icon: Leaf,
+    achievements: [
+      {
+        name: 'Fresh legs framework',
+        detail: 'We will add freshness-focused achievements soon—this category is built to expand.',
+      },
+    ],
+  },
+];
+
+type AchievementSectionProps = {
+  className?: string;
+};
+
+export function AchievementSection({ className }: AchievementSectionProps) {
+  return (
+    <section
+      className={cn(
+        'space-y-8 rounded-3xl border bg-background/70 p-8 shadow-inner shadow-primary/10 md:p-12',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-3">
+          <h2 className="text-2xl font-semibold tracking-tight text-foreground">Achievement tracker</h2>
+          <p className="text-sm text-muted-foreground">
+            Celebrate standout efforts across climbing, durability, and freshness. Achievements refresh every six months so
+            riders always have new benchmarks to chase.
+          </p>
+        </div>
+        <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-primary">
+          6-month reset
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-3">
+        {achievementCategories.map((category) => (
+          <Card key={category.title} className="h-full border-primary/15 bg-background/80">
+            <CardHeader className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <category.icon className="h-5 w-5" aria-hidden />
+                </div>
+                <div>
+                  <CardTitle className="text-lg font-semibold text-foreground">{category.title}</CardTitle>
+                  <CardDescription>{category.description}</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {category.achievements.map((achievement) => (
+                  <li key={achievement.name} className="rounded-xl border border-primary/10 bg-background/90 p-3">
+                    <p className="text-sm font-semibold text-foreground">{achievement.name}</p>
+                    <p className="text-xs text-muted-foreground">{achievement.detail}</p>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -22,6 +22,7 @@ const baseNavItems: NavItem[] = [
     label: 'Analytics',
     matchers: ['/activities/trends', '/moving-averages', '/durability-analysis', '/training-frontiers'],
   },
+  { href: '/achievements', label: 'Achievements' },
   {
     href: '/metrics/registry',
     label: 'Metric library',


### PR DESCRIPTION
## Summary
- extract the achievements content into a reusable section component
- add a dedicated /achievements route that highlights the tracker experience
- surface the achievements link in the primary navigation so it is easy to reach

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68e0bf64d67483308539cfff58443a08