### PR TITLE
Add durable TSS explorer

### DIFF
--- a/apps/backend/src/routes/durableTss.ts
+++ b/apps/backend/src/routes/durableTss.ts
@@ -1,0 +1,76 @@
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
+
+import { env } from '../env.js';
+import { getDurableTss } from '../services/durableTssService.js';
+
+function firstValue(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return typeof value === 'string' ? value : undefined;
+}
+
+const filtersSchema = z.object({
+  thresholdKj: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => value === undefined || !Number.isNaN(Number(value)), {
+      message: 'thresholdKj must be numeric',
+    }),
+  startDate: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => value === undefined || !Number.isNaN(Date.parse(value)), {
+      message: 'startDate must be a valid date',
+    }),
+  endDate: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => value === undefined || !Number.isNaN(Date.parse(value)), {
+      message: 'endDate must be a valid date',
+    }),
+});
+
+const DEFAULT_THRESHOLD_KJ = 1000;
+
+export const durableTssRouter = express.Router();
+
+durableTssRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    if (env.AUTH_ENABLED && !req.user?.id) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const raw = {
+      thresholdKj: firstValue(req.query.thresholdKj),
+      startDate: firstValue(req.query.startDate),
+      endDate: firstValue(req.query.endDate),
+    };
+
+    const parsed = filtersSchema.safeParse(raw);
+    if (!parsed.success) {
+      const message = parsed.error.errors.at(0)?.message ?? 'Invalid filters provided.';
+      res.status(400).json({ error: message });
+      return;
+    }
+
+    const thresholdKjValue = parsed.data.thresholdKj != null ? Number(parsed.data.thresholdKj) : undefined;
+    const filters = {
+      thresholdKj: thresholdKjValue ?? DEFAULT_THRESHOLD_KJ,
+      startDate: parsed.data.startDate ? new Date(parsed.data.startDate) : undefined,
+      endDate: parsed.data.endDate ? new Date(parsed.data.endDate) : undefined,
+    };
+
+    const userId = req.user!.id;
+    const response = await getDurableTss(userId, filters);
+
+    res.json(response);
+  }),
+);

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import { metricsRouter } from './metrics.js';
 import { profileRouter } from './profile.js';
 import { uploadRouter } from './upload.js';
 import { durabilityAnalysisRouter } from './durabilityAnalysis.js';
+import { durableTssRouter } from './durableTss.js';
 import { trainingFrontiersRouter } from './trainingFrontiers.js';
 
 export const apiRouter = express.Router();
@@ -18,4 +19,5 @@ apiRouter.use('/activities', requireAuth, activitiesRouter);
 apiRouter.use('/metrics', requireAuth, metricsRouter);
 apiRouter.use('/profile', requireAuth, profileRouter);
 apiRouter.use('/durability-analysis', requireAuth, durabilityAnalysisRouter);
+apiRouter.use('/durable-tss', requireAuth, durableTssRouter);
 apiRouter.use('/training-frontiers', requireAuth, trainingFrontiersRouter);

--- a/apps/backend/src/services/durableTssService.ts
+++ b/apps/backend/src/services/durableTssService.ts
@@ -1,0 +1,221 @@
+import type { Activity, Prisma } from '@prisma/client';
+
+import { prisma } from '../prisma.js';
+import type { MetricSample } from '../metrics/types.js';
+import { computeNormalizedPower, extractPowerSamples } from '../utils/power.js';
+
+const NORMALIZED_WINDOW_SECONDS = 30;
+const MIN_THRESHOLD_KJ = 1;
+const MAX_THRESHOLD_KJ = 5000;
+
+interface ActivityWithSamples extends Activity {
+  samples: Array<{ t: number; power: number | null; heartRate: number | null }>;
+}
+
+export interface DurableTssFilters {
+  thresholdKj: number;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export interface DurableTssRide {
+  activityId: string;
+  startTime: string;
+  source: string;
+  totalKj: number | null;
+  postThresholdKj: number | null;
+  postThresholdDurationSec: number | null;
+  durableTss: number | null;
+}
+
+export interface DurableTssResponse {
+  ftpWatts: number | null;
+  thresholdKj: number;
+  filters: DurableTssFilters;
+  rides: DurableTssRide[];
+}
+
+function clampThreshold(value: number): number {
+  if (Number.isNaN(value)) {
+    return MIN_THRESHOLD_KJ;
+  }
+  if (value < MIN_THRESHOLD_KJ) {
+    return MIN_THRESHOLD_KJ;
+  }
+  if (value > MAX_THRESHOLD_KJ) {
+    return MAX_THRESHOLD_KJ;
+  }
+  return Math.round(value);
+}
+
+function toMetricSamples(
+  samples: Array<{ t: number; power: number | null; heartRate: number | null }>,
+): MetricSample[] {
+  return samples
+    .map((sample) => ({
+      t: sample.t,
+      power: sample.power ?? null,
+      heartRate: sample.heartRate ?? null,
+      cadence: null,
+      speed: null,
+      elevation: null,
+      temperature: null,
+    }))
+    .sort((a, b) => a.t - b.t);
+}
+
+function inferSampleRate(activity: Activity, samples: MetricSample[]): number {
+  if (activity.sampleRateHz && activity.sampleRateHz > 0) {
+    return activity.sampleRateHz;
+  }
+
+  if (samples.length >= 2) {
+    const first = samples[0]!;
+    const last = samples[samples.length - 1]!;
+    const delta = last.t - first.t;
+    if (delta > 0) {
+      return (samples.length - 1) / delta;
+    }
+  }
+
+  if (activity.durationSec > 0 && samples.length > 0) {
+    return samples.length / activity.durationSec;
+  }
+
+  return 1;
+}
+
+function roundNumber(value: number | null, fractionDigits = 1): number | null {
+  if (value == null || !Number.isFinite(value)) {
+    return null;
+  }
+  const factor = 10 ** fractionDigits;
+  return Math.round(value * factor) / factor;
+}
+
+function computeDurableTssForActivity(
+  activity: ActivityWithSamples,
+  ftpWatts: number | null,
+  thresholdKj: number,
+): DurableTssRide {
+  const metricSamples = toMetricSamples(activity.samples);
+  const sampleRate = inferSampleRate(activity, metricSamples);
+
+  if (metricSamples.length === 0 || sampleRate <= 0) {
+    return {
+      activityId: activity.id,
+      startTime: activity.startTime.toISOString(),
+      source: activity.source,
+      totalKj: null,
+      postThresholdKj: null,
+      postThresholdDurationSec: null,
+      durableTss: null,
+    };
+  }
+
+  const interval = 1 / sampleRate;
+  const thresholdJoules = thresholdKj * 1000;
+  let cumulativeJoules = 0;
+  let postThresholdJoules = 0;
+  let startIndex: number | null = null;
+
+  for (let index = 0; index < metricSamples.length; index += 1) {
+    const sample = metricSamples[index]!;
+    const power = typeof sample.power === 'number' && Number.isFinite(sample.power) ? sample.power : null;
+    const joules = power != null ? power * interval : 0;
+
+    if (startIndex != null) {
+      postThresholdJoules += joules;
+    } else if (cumulativeJoules + joules >= thresholdJoules) {
+      startIndex = index;
+      const overshoot = cumulativeJoules + joules - thresholdJoules;
+      if (overshoot > 0) {
+        postThresholdJoules += overshoot;
+      }
+    }
+
+    cumulativeJoules += joules;
+  }
+
+  const totalKj = roundNumber(cumulativeJoules / 1000, 1);
+  const postThresholdKj = startIndex != null ? roundNumber(postThresholdJoules / 1000, 1) : null;
+
+  let durableTss: number | null = null;
+  let postThresholdDurationSec: number | null = null;
+
+  if (startIndex != null) {
+    const segmentSamples = metricSamples.slice(startIndex);
+    postThresholdDurationSec = roundNumber(segmentSamples.length * interval, 0);
+
+    if (ftpWatts && ftpWatts > 0 && segmentSamples.length > 0) {
+      const powerSamples = extractPowerSamples(segmentSamples);
+      const windowSize = Math.max(1, Math.round(NORMALIZED_WINDOW_SECONDS * sampleRate));
+      const { normalizedPower } = computeNormalizedPower(powerSamples, windowSize);
+      if (normalizedPower != null && Number.isFinite(normalizedPower) && powerSamples.length > 0) {
+        const intensityFactor = normalizedPower / ftpWatts;
+        const durationHours = (segmentSamples.length * interval) / 3600;
+        if (durationHours > 0) {
+          const tss = intensityFactor * intensityFactor * durationHours * 100;
+          durableTss = roundNumber(tss, 1);
+        }
+      }
+    }
+  }
+
+  return {
+    activityId: activity.id,
+    startTime: activity.startTime.toISOString(),
+    source: activity.source,
+    totalKj,
+    postThresholdKj,
+    postThresholdDurationSec,
+    durableTss,
+  };
+}
+
+export async function getDurableTss(userId: string, filters: DurableTssFilters): Promise<DurableTssResponse> {
+  const profile = await prisma.profile.findUnique({ where: { userId } });
+  const ftpWatts = profile?.ftpWatts ?? null;
+
+  const thresholdKj = clampThreshold(filters.thresholdKj);
+
+  const where: Prisma.ActivityWhereInput = {
+    userId,
+  };
+
+  if (filters.startDate || filters.endDate) {
+    where.startTime = {};
+    if (filters.startDate) {
+      where.startTime.gte = filters.startDate;
+    }
+    if (filters.endDate) {
+      where.startTime.lte = filters.endDate;
+    }
+  }
+
+  const activities = (await prisma.activity.findMany({
+    where,
+    orderBy: { startTime: 'asc' },
+    include: {
+      samples: {
+        orderBy: { t: 'asc' },
+        select: { t: true, power: true, heartRate: true },
+      },
+    },
+  })) as ActivityWithSamples[];
+
+  const rides = activities
+    .filter((activity) => activity.samples.length > 0)
+    .map((activity) => computeDurableTssForActivity(activity, ftpWatts, thresholdKj));
+
+  return {
+    ftpWatts,
+    thresholdKj,
+    filters: {
+      thresholdKj,
+      startDate: filters.startDate,
+      endDate: filters.endDate,
+    },
+    rides,
+  };
+}

--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -24,6 +24,12 @@ const analyticsTools = [
     action: 'Run durability checks',
   },
   {
+    title: 'Durable TSS explorer',
+    description: 'Plot late-ride training load by calculating TSS only after your chosen kilojoule marker.',
+    href: '/durable-tss',
+    action: 'Inspect durable TSS',
+  },
+  {
     title: 'Training frontiers',
     description: 'Identify your peak duration-power, durability, efficiency, and repeatability records by recency.',
     href: '/training-frontiers',

--- a/apps/web/app/durable-tss/page.tsx
+++ b/apps/web/app/durable-tss/page.tsx
@@ -1,0 +1,72 @@
+import { redirect } from 'next/navigation';
+
+import { DurableTssClient } from '../../components/durable-tss-client';
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
+import { getServerAuthSession } from '../../lib/auth';
+import { env } from '../../lib/env';
+import type { DurableTssResponse } from '../../types/durable-tss';
+
+const DEFAULT_THRESHOLD_KJ = 1000;
+
+async function loadInitialDurableTss(token?: string): Promise<DurableTssResponse | null> {
+  const headers: HeadersInit | undefined = token ? { Authorization: `Bearer ${token}` } : undefined;
+  try {
+    const response = await fetch(
+      `${env.internalApiUrl}/durable-tss?thresholdKj=${DEFAULT_THRESHOLD_KJ}`,
+      {
+        cache: 'no-store',
+        headers,
+      },
+    );
+
+    if (!response.ok) {
+      console.error('Failed to load durable TSS response', response.statusText);
+      return null;
+    }
+
+    return (await response.json()) as DurableTssResponse;
+  } catch (error) {
+    console.error('Unable to fetch durable TSS response', error);
+    return null;
+  }
+}
+
+export default async function DurableTssPage() {
+  const session = await getServerAuthSession();
+  if (env.authEnabled && !session) {
+    redirect('/signin');
+  }
+
+  const initialData = await loadInitialDurableTss(session?.accessToken);
+
+  if (!initialData) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold">Durable TSS explorer</h1>
+          <p className="text-muted-foreground">
+            Visualize the training load you accumulate once fatigue sets in and your kilojoule burn passes a critical threshold.
+          </p>
+        </div>
+        <Alert variant="destructive">
+          <AlertTitle>Unable to load durable TSS data</AlertTitle>
+          <AlertDescription>
+            Ensure the API is reachable and that your rides include power data. Try again after verifying your connection.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Durable TSS explorer</h1>
+        <p className="text-muted-foreground">
+          Quantify how much structured stress you carry deep into rides by calculating TSS only after a chosen kilojoule mark.
+        </p>
+      </div>
+      <DurableTssClient initialData={initialData} defaultThresholdKj={DEFAULT_THRESHOLD_KJ} />
+    </div>
+  );
+}

--- a/apps/web/components/durable-tss-client.tsx
+++ b/apps/web/components/durable-tss-client.tsx
@@ -1,0 +1,467 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import useSWR from 'swr';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { fetchDurableTss, type DurableTssFilters } from '../lib/api';
+import { formatDuration } from '../lib/utils';
+import type { DurableTssResponse } from '../types/durable-tss';
+import { Alert, AlertDescription, AlertTitle } from './ui/alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Input } from './ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
+import { Button } from './ui/button';
+
+const MIN_THRESHOLD_KJ = 1;
+const MAX_THRESHOLD_KJ = 5000;
+
+interface DurableTssClientProps {
+  initialData: DurableTssResponse | null;
+  defaultThresholdKj: number;
+}
+
+type FiltersState = DurableTssFilters;
+
+type ChartPoint = {
+  timestamp: number;
+  dateLabel: string;
+  source: string;
+  durableTss: number | null;
+  postThresholdKj: number | null;
+  postThresholdDurationSec: number | null;
+};
+
+function clampThreshold(value: number): number {
+  if (Number.isNaN(value)) {
+    return MIN_THRESHOLD_KJ;
+  }
+  if (value < MIN_THRESHOLD_KJ) {
+    return MIN_THRESHOLD_KJ;
+  }
+  if (value > MAX_THRESHOLD_KJ) {
+    return MAX_THRESHOLD_KJ;
+  }
+  return Math.round(value);
+}
+
+function formatNumber(value: number | null | undefined, fractionDigits = 1): string {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  return value.toFixed(fractionDigits);
+}
+
+function useDurableTssData(filters: FiltersState, initialData: DurableTssResponse | null) {
+  const { data: session, status } = useSession();
+  const token = session?.accessToken;
+
+  const swrKey = useMemo(() => {
+    if (status === 'loading') {
+      return null;
+    }
+    return ['durable-tss', filters, token] as const;
+  }, [filters, status, token]);
+
+  const { data, isLoading, error } = useSWR(
+    swrKey,
+    async ([, filterState, authToken]) => fetchDurableTss(filterState, authToken ?? undefined),
+    {
+      keepPreviousData: true,
+      fallbackData: initialData ?? undefined,
+      revalidateOnFocus: false,
+    },
+  );
+
+  return { data: data ?? null, isLoading, error: error as Error | undefined };
+}
+
+function DurableTssTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const point = payload[0]?.payload as ChartPoint | undefined;
+  if (!point) {
+    return null;
+  }
+
+  return (
+    <div className="min-w-[200px] rounded-md border bg-background/95 p-3 text-xs shadow-lg">
+      <p className="font-semibold text-foreground">{point.dateLabel}</p>
+      <p className="text-muted-foreground">Source: {point.source}</p>
+      <div className="mt-2 space-y-1">
+        <p>
+          Durable TSS: <span className="font-medium text-foreground">{formatNumber(point.durableTss, 1)}</span>
+        </p>
+        <p>
+          Post-threshold energy:{' '}
+          <span className="font-medium text-foreground">{formatNumber(point.postThresholdKj, 1)} kJ</span>
+        </p>
+        <p>
+          Duration after threshold:{' '}
+          <span className="font-medium text-foreground">
+            {point.postThresholdDurationSec != null ? formatDuration(point.postThresholdDurationSec) : '—'}
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function DurableTssClient({ initialData, defaultThresholdKj }: DurableTssClientProps) {
+  const initialThreshold = clampThreshold(initialData?.thresholdKj ?? defaultThresholdKj);
+  const initialStart = initialData?.filters.startDate?.slice(0, 10);
+  const initialEnd = initialData?.filters.endDate?.slice(0, 10);
+
+  const [pending, setPending] = useState<FiltersState>({
+    thresholdKj: initialThreshold,
+    startDate: initialStart,
+    endDate: initialEnd,
+  });
+  const [filters, setFilters] = useState<FiltersState>(pending);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setFilters(pending);
+    }, 300);
+    return () => window.clearTimeout(handle);
+  }, [pending]);
+
+  const { data, isLoading, error } = useDurableTssData(filters, initialData);
+
+  const chartDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    [],
+  );
+
+  const chartData = useMemo<ChartPoint[]>(() => {
+    if (!data) {
+      return [];
+    }
+    return data.rides
+      .map((ride) => {
+        const timestamp = new Date(ride.startTime).getTime();
+        return {
+          timestamp,
+          dateLabel: chartDateFormatter.format(new Date(ride.startTime)),
+          source: ride.source,
+          durableTss: ride.durableTss,
+          postThresholdKj: ride.postThresholdKj,
+          postThresholdDurationSec: ride.postThresholdDurationSec,
+        } satisfies ChartPoint;
+      })
+      .sort((a, b) => a.timestamp - b.timestamp);
+  }, [chartDateFormatter, data]);
+
+  const stats = useMemo(() => {
+    if (!data) {
+      return {
+        rideCount: 0,
+        averageDurableTss: null,
+        averagePostKj: null,
+        averageDurationSec: null,
+      };
+    }
+
+    const ridesWithDurableTss = data.rides.filter((ride) => ride.durableTss != null);
+    const rideCount = data.rides.length;
+    if (ridesWithDurableTss.length === 0) {
+      return {
+        rideCount,
+        averageDurableTss: null,
+        averagePostKj: null,
+        averageDurationSec: null,
+      };
+    }
+
+    const totals = ridesWithDurableTss.reduce(
+      (acc, ride) => {
+        acc.durableTss += ride.durableTss ?? 0;
+        acc.postKj += ride.postThresholdKj ?? 0;
+        acc.durationSec += ride.postThresholdDurationSec ?? 0;
+        return acc;
+      },
+      { durableTss: 0, postKj: 0, durationSec: 0 },
+    );
+
+    const count = ridesWithDurableTss.length;
+    return {
+      rideCount,
+      averageDurableTss: totals.durableTss / count,
+      averagePostKj: totals.postKj / count,
+      averageDurationSec: totals.durationSec / count,
+    };
+  }, [data]);
+
+  const startLabelFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    [],
+  );
+  const timeLabelFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-US', {
+        hour: 'numeric',
+        minute: 'numeric',
+      }),
+    [],
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-base font-semibold">Durable TSS filters</CardTitle>
+          <CardDescription>
+            Choose a date window and adjust the kilojoule threshold to focus on late-ride training load.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="durable-tss-start">
+                Start date
+              </label>
+              <Input
+                id="durable-tss-start"
+                type="date"
+                value={pending.startDate ?? ''}
+                onChange={(event) =>
+                  setPending((prev) => ({ ...prev, startDate: event.target.value || undefined }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="durable-tss-end">
+                End date
+              </label>
+              <Input
+                id="durable-tss-end"
+                type="date"
+                value={pending.endDate ?? ''}
+                onChange={(event) =>
+                  setPending((prev) => ({ ...prev, endDate: event.target.value || undefined }))
+                }
+              />
+            </div>
+            <div className="flex items-end">
+              <Button
+                type="button"
+                variant="secondary"
+                className="w-full"
+                onClick={() => setPending((prev) => ({ ...prev, startDate: undefined, endDate: undefined }))}
+              >
+                Clear dates
+              </Button>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-sm">
+              <label className="font-medium text-foreground" htmlFor="durable-tss-threshold">
+                Kilojoule threshold
+              </label>
+              <span className="text-muted-foreground">{pending.thresholdKj} kJ</span>
+            </div>
+            <input
+              id="durable-tss-threshold"
+              type="range"
+              min={MIN_THRESHOLD_KJ}
+              max={MAX_THRESHOLD_KJ}
+              value={pending.thresholdKj}
+              onChange={(event) =>
+                setPending((prev) => ({ ...prev, thresholdKj: clampThreshold(Number(event.target.value)) }))
+              }
+              className="h-2 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
+            />
+            <Input
+              type="number"
+              min={MIN_THRESHOLD_KJ}
+              max={MAX_THRESHOLD_KJ}
+              value={pending.thresholdKj}
+              onChange={(event) =>
+                setPending((prev) => ({
+                  ...prev,
+                  thresholdKj: clampThreshold(Number(event.target.value)),
+                }))
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Unable to load durable TSS</AlertTitle>
+          <AlertDescription>
+            {error.message || 'The analysis request failed. Try refreshing or adjusting your filters.'}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {data?.ftpWatts == null ? (
+        <Alert>
+          <AlertTitle>Set your FTP to unlock TSS calculations</AlertTitle>
+          <AlertDescription>
+            Provide an FTP value in your profile so we can translate post-threshold intensity into training stress.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Rides analyzed</CardDescription>
+            <CardTitle className="text-3xl font-semibold">{stats.rideCount}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Average durable TSS</CardDescription>
+            <CardTitle className="text-3xl font-semibold">
+              {formatNumber(stats.averageDurableTss, 1)}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Average post-threshold energy</CardDescription>
+            <CardTitle className="text-3xl font-semibold">
+              {formatNumber(stats.averagePostKj, 1)} kJ
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Average time after threshold</CardDescription>
+            <CardTitle className="text-3xl font-semibold">
+              {stats.averageDurationSec != null
+                ? formatDuration(stats.averageDurationSec)
+                : '—'}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-base font-semibold">Durable TSS over time</CardTitle>
+          <CardDescription>
+            Track how much training load you generate after {filters.thresholdKj} kJ of work across your selected rides.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[360px]">
+          {chartData.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              {isLoading ? 'Loading durable TSS trend…' : 'No rides match your current filters.'}
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 12, right: 24, left: 8, bottom: 12 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey="timestamp"
+                  type="number"
+                  tickFormatter={(value) => startLabelFormatter.format(new Date(value))}
+                  domain={['auto', 'auto']}
+                  className="text-xs"
+                />
+                <YAxis
+                  dataKey="durableTss"
+                  name="Durable TSS"
+                  className="text-xs"
+                  domain={[0, 'auto']}
+                  tickFormatter={(value) => Number.isFinite(value) ? value.toFixed(0) : ''}
+                />
+                <Tooltip content={<DurableTssTooltip />} />
+                <Line
+                  type="monotone"
+                  dataKey="durableTss"
+                  stroke="var(--primary)"
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                  connectNulls
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-base font-semibold">Ride breakdown</CardTitle>
+          <CardDescription>
+            Review individual rides, late-ride duration, and energy accumulation beyond the selected threshold.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data && data.rides.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Durable TSS</TableHead>
+                  <TableHead>Post-threshold kJ</TableHead>
+                  <TableHead>Duration after threshold</TableHead>
+                  <TableHead>Total kJ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.rides
+                  .slice()
+                  .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
+                  .map((ride) => (
+                    <TableRow key={ride.activityId}>
+                      <TableCell className="whitespace-nowrap">
+                        <div className="font-medium text-foreground">{startLabelFormatter.format(new Date(ride.startTime))}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {timeLabelFormatter.format(new Date(ride.startTime))}
+                        </div>
+                      </TableCell>
+                      <TableCell>{ride.source}</TableCell>
+                      <TableCell>{formatNumber(ride.durableTss, 1)}</TableCell>
+                      <TableCell>{formatNumber(ride.postThresholdKj, 1)}</TableCell>
+                      <TableCell>
+                        {ride.postThresholdDurationSec != null
+                          ? formatDuration(ride.postThresholdDurationSec)
+                          : '—'}
+                      </TableCell>
+                      <TableCell>{formatNumber(ride.totalKj, 1)}</TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {isLoading
+                ? 'Loading ride breakdown…'
+                : 'Upload endurance rides to see how much training load you generate after your chosen kilojoule marker.'}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -16,6 +16,7 @@ import type { AdaptationEdgesResponse } from '../types/adaptation';
 import type { DurabilityAnalysisResponse } from '../types/durability-analysis';
 import type { DepthAnalysisResponse } from '../types/depth-analysis';
 import type { TrainingFrontiersResponse } from '../types/training-frontiers';
+import type { DurableTssFilters as DurableTssFiltersResponse, DurableTssResponse } from '../types/durable-tss';
 
 async function apiFetch<T>(path: string, init?: RequestInit, authToken?: string): Promise<T> {
   const url = path.startsWith('http') ? path : `${env.apiUrl}${path}`;
@@ -155,6 +156,21 @@ export async function fetchDurabilityAnalysis(
   const search = params.toString();
   const path = search.length > 0 ? `/durability-analysis?${search}` : '/durability-analysis';
   return apiFetch<DurabilityAnalysisResponse>(path, undefined, authToken);
+}
+
+export type DurableTssFilters = DurableTssFiltersResponse;
+
+export async function fetchDurableTss(filters: DurableTssFilters, authToken?: string) {
+  const params = new URLSearchParams({ thresholdKj: String(filters.thresholdKj) });
+  if (filters.startDate) {
+    params.set('startDate', filters.startDate);
+  }
+  if (filters.endDate) {
+    params.set('endDate', filters.endDate);
+  }
+
+  const path = `/durable-tss?${params.toString()}`;
+  return apiFetch<DurableTssResponse>(path, undefined, authToken);
 }
 
 export async function fetchTrainingFrontiers(windowDays?: number, authToken?: string) {

--- a/apps/web/types/durable-tss.ts
+++ b/apps/web/types/durable-tss.ts
@@ -1,0 +1,22 @@
+export interface DurableTssRide {
+  activityId: string;
+  startTime: string;
+  source: string;
+  totalKj: number | null;
+  postThresholdKj: number | null;
+  postThresholdDurationSec: number | null;
+  durableTss: number | null;
+}
+
+export interface DurableTssFilters {
+  thresholdKj: number;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface DurableTssResponse {
+  ftpWatts: number | null;
+  thresholdKj: number;
+  filters: DurableTssFilters;
+  rides: DurableTssRide[];
+}


### PR DESCRIPTION
## Summary
- add a backend durable TSS endpoint that computes post-threshold training load per ride and exposes it via the API
- create a durable TSS explorer page with slider-controlled kilojoule thresholding, date filters, charts, and tables
- wire the new explorer into the analytics hub, shared types, and API client helpers

## Testing
- pnpm --filter backend lint *(fails: existing import-order violations in unrelated files)*
- pnpm --filter web lint


------
https://chatgpt.com/codex/tasks/task_e_68e115e41b30833093d230ef6e7b5659