### PR TITLE
Add achievement trophy case and navigation dropdowns

### DIFF
--- a/apps/web/app/achievements/page.tsx
+++ b/apps/web/app/achievements/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { AchievementSection } from '../../components/achievement-section';
+import { TrophyCase } from '../../components/trophy-case';
 
 export const metadata: Metadata = {
   title: 'Achievements | Cycling Custom Metrics',
@@ -26,7 +27,8 @@ export default function AchievementsPage() {
         </div>
       </section>
 
-      <AchievementSection className="shadow-lg shadow-primary/5" />
+      <TrophyCase id="trophy-case" />
+      <AchievementSection id="tracker" className="shadow-lg shadow-primary/5" />
     </div>
   );
 }

--- a/apps/web/components/achievement-section.tsx
+++ b/apps/web/components/achievement-section.tsx
@@ -1,9 +1,23 @@
+import type { LucideIcon } from 'lucide-react';
 import { Leaf, Mountain, ShieldCheck } from 'lucide-react';
 
 import { cn } from '../lib/utils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
 
-export const achievementCategories = [
+type Achievement = {
+  name: string;
+  detail: string;
+  activity: string;
+};
+
+type AchievementCategory = {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  achievements: Achievement[];
+};
+
+export const achievementCategories: AchievementCategory[] = [
   {
     title: 'Climbing',
     description: 'Benchmark vertical strength with elevation-focused challenges.',
@@ -12,6 +26,12 @@ export const achievementCategories = [
       {
         name: 'Summit seeker',
         detail: 'Complete a ride with over 1,000 meters of elevation gain.',
+        activity: 'Earned during the Queenstown alpine build ride',
+      },
+      {
+        name: 'Switchback specialist',
+        detail: 'Finish a set of six hill repeats above 8% grade with negative splits.',
+        activity: 'Awarded on the St. Helens repeatability session',
       },
     ],
   },
@@ -23,10 +43,12 @@ export const achievementCategories = [
       {
         name: 'FTP endurance',
         detail: 'Hold 90% of FTP for an hour after accumulating three hours of Zone 2 kilojoules.',
+        activity: 'Set on the Lakeside century with negative-split finish',
       },
       {
         name: 'VO2 staying power',
         detail: 'Hold 90% of your five-minute power best after three hours of Zone 2 kilojoules.',
+        activity: 'Captured in the High Country gravel epic finale',
       },
     ],
   },
@@ -38,6 +60,12 @@ export const achievementCategories = [
       {
         name: 'Fresh legs framework',
         detail: 'We will add freshness-focused achievements soon—this category is built to expand.',
+        activity: 'Most recently unlocked after the taper tune-up ride',
+      },
+      {
+        name: 'Acceleration ace',
+        detail: 'Produce three consecutive sprints within 5% of your personal best after rest day recovery.',
+        activity: 'Validated on the criterium opener warm-up',
       },
     ],
   },
@@ -45,11 +73,13 @@ export const achievementCategories = [
 
 type AchievementSectionProps = {
   className?: string;
+  id?: string;
 };
 
-export function AchievementSection({ className }: AchievementSectionProps) {
+export function AchievementSection({ className, id }: AchievementSectionProps) {
   return (
     <section
+      id={id}
       className={cn(
         'space-y-8 rounded-3xl border bg-background/70 p-8 shadow-inner shadow-primary/10 md:p-12',
         className,
@@ -87,6 +117,7 @@ export function AchievementSection({ className }: AchievementSectionProps) {
                   <li key={achievement.name} className="rounded-xl border border-primary/10 bg-background/90 p-3">
                     <p className="text-sm font-semibold text-foreground">{achievement.name}</p>
                     <p className="text-xs text-muted-foreground">{achievement.detail}</p>
+                    <p className="mt-2 text-xs font-medium text-primary">{achievement.activity}</p>
                   </li>
                 ))}
               </ul>

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
+import { ChevronDown } from 'lucide-react';
 import { signIn, signOut, useSession } from 'next-auth/react';
 
 import { env } from '../lib/env';
@@ -8,11 +10,32 @@ import { cn } from '../lib/utils';
 import { useSafePathname } from '../hooks/use-safe-pathname';
 import { Button } from './ui/button';
 
+type NavChild = {
+  href: string;
+  label: string;
+};
+
 type NavItem = {
   href: string;
   label: string;
   matchers?: string[];
+  children?: NavChild[];
 };
+
+const analyticsChildren: NavChild[] = [
+  { href: '/analytics', label: 'Analytics hub' },
+  { href: '/activities/trends', label: 'Activity trends' },
+  { href: '/moving-averages', label: 'Moving averages' },
+  { href: '/durability-analysis', label: 'Durability analysis' },
+  { href: '/durable-tss', label: 'Durable TSS explorer' },
+  { href: '/training-frontiers', label: 'Training frontiers' },
+];
+
+const achievementsChildren: NavChild[] = [
+  { href: '/achievements', label: 'Achievements hub' },
+  { href: '/achievements#tracker', label: 'Achievement tracker' },
+  { href: '/achievements#trophy-case', label: 'Trophy case' },
+];
 
 const baseNavItems: NavItem[] = [
   { href: '/', label: 'Overview' },
@@ -20,9 +43,15 @@ const baseNavItems: NavItem[] = [
   {
     href: '/analytics',
     label: 'Analytics',
-    matchers: ['/activities/trends', '/moving-averages', '/durability-analysis', '/training-frontiers'],
+    matchers: ['/activities/trends', '/moving-averages', '/durability-analysis', '/training-frontiers', '/durable-tss'],
+    children: analyticsChildren,
   },
-  { href: '/achievements', label: 'Achievements' },
+  {
+    href: '/achievements',
+    label: 'Achievements',
+    matchers: ['/achievements'],
+    children: achievementsChildren,
+  },
   {
     href: '/metrics/registry',
     label: 'Metric library',
@@ -60,11 +89,14 @@ function AuthControls() {
 export function SiteHeader() {
   const pathname = useSafePathname();
   const { status } = useSession();
+  const [openDropdown, setOpenDropdown] = useState<string | null>(null);
 
   const navItems: NavItem[] =
     status === 'authenticated'
       ? [...baseNavItems, { href: '/profile', label: 'Profile', matchers: ['/profile'] }]
       : baseNavItems;
+
+  const closeDropdown = () => setOpenDropdown(null);
 
   return (
     <header className="border-b">
@@ -75,31 +107,98 @@ export function SiteHeader() {
         <nav className="flex items-center gap-1 text-sm font-medium">
           {navItems.map((item) => {
             const matchers = item.matchers ?? [];
+            const childMatchers = item.children?.map((child) => child.href.split('#')[0]) ?? [];
+            const normalizedMatchers = [...new Set([...matchers, ...childMatchers])];
             const isActive =
               pathname === item.href ||
               (item.href !== '/' && pathname.startsWith(`${item.href}/`)) ||
-              matchers.some(
-                (matcher) =>
-                  pathname === matcher ||
-                  (matcher !== '/' && pathname.startsWith(`${matcher}/`)),
+              normalizedMatchers.some(
+                (matcher) => pathname === matcher || (matcher !== '/' && pathname.startsWith(`${matcher}/`)),
               );
+
+            if (!item.children?.length) {
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(
+                    'relative rounded-md px-3 py-2 transition-colors',
+                    isActive
+                      ? 'bg-primary/10 text-foreground'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {item.label}
+                  {isActive ? (
+                    <span className="absolute inset-x-1 bottom-1 h-0.5 rounded-full bg-primary" aria-hidden />
+                  ) : null}
+                </Link>
+              );
+            }
+
+            const dropdownOpen = openDropdown === item.href;
+
             return (
-              <Link
+              <div
                 key={item.href}
-                href={item.href}
-                className={cn(
-                  'relative rounded-md px-3 py-2 transition-colors',
-                  isActive
-                    ? 'bg-primary/10 text-foreground'
-                    : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                )}
-                aria-current={isActive ? 'page' : undefined}
+                className="relative"
+                onMouseEnter={() => setOpenDropdown(item.href)}
+                onMouseLeave={closeDropdown}
+                onFocus={() => setOpenDropdown(item.href)}
+                onBlur={(event) => {
+                  const nextFocus = event.relatedTarget as Node | null;
+                  if (!nextFocus || !event.currentTarget.contains(nextFocus)) {
+                    closeDropdown();
+                  }
+                }}
               >
-                {item.label}
-                {isActive ? (
-                  <span className="absolute inset-x-1 bottom-1 h-0.5 rounded-full bg-primary" aria-hidden />
-                ) : null}
-              </Link>
+                <button
+                  type="button"
+                  className={cn(
+                    'relative flex items-center gap-1 rounded-md px-3 py-2 transition-colors',
+                    isActive
+                      ? 'bg-primary/10 text-foreground'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                  aria-haspopup="menu"
+                  aria-expanded={dropdownOpen}
+                  onClick={() =>
+                    setOpenDropdown((current) => (current === item.href ? null : item.href))
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      event.stopPropagation();
+                      closeDropdown();
+                    }
+                  }}
+                >
+                  {item.label}
+                  <ChevronDown className="h-3 w-3" aria-hidden />
+                  {isActive ? (
+                    <span className="absolute inset-x-1 bottom-1 h-0.5 rounded-full bg-primary" aria-hidden />
+                  ) : null}
+                </button>
+                <div
+                  className={cn(
+                    'absolute right-0 z-20 mt-2 w-56 rounded-lg border bg-background p-2 text-sm shadow-lg transition-all duration-150',
+                    dropdownOpen ? 'visible translate-y-0 opacity-100' : 'invisible -translate-y-1 opacity-0',
+                  )}
+                  role="menu"
+                >
+                  {item.children?.map((child) => (
+                    <Link
+                      key={child.href}
+                      href={child.href}
+                      className="block rounded-md px-3 py-2 text-left text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                      onClick={closeDropdown}
+                      role="menuitem"
+                    >
+                      {child.label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
             );
           })}
         </nav>

--- a/apps/web/components/trophy-case.tsx
+++ b/apps/web/components/trophy-case.tsx
@@ -1,0 +1,93 @@
+import type { LucideIcon } from 'lucide-react';
+import { Award, Crown, Medal, Trophy } from 'lucide-react';
+
+import { cn } from '../lib/utils';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+
+type TrophyHighlight = {
+  title: string;
+  description: string;
+  metricHighlight: string;
+  activity: string;
+  icon: LucideIcon;
+};
+
+const trophyHighlights: TrophyHighlight[] = [
+  {
+    title: 'Gran Fondo Guardian',
+    description: 'Completed four consecutive 160km rides with rising normalized power each week.',
+    metricHighlight: 'Best four-week fatigue resistance trend',
+    activity: 'Anchored by the Coast-to-Summit Gran Fondo',
+    icon: Trophy,
+  },
+  {
+    title: 'Efficiency Maestro',
+    description: 'Delivered a 1.1% improvement in aerobic decoupling during a five-hour endurance ride.',
+    metricHighlight: 'Lowest heart-rate drift at endurance pace',
+    activity: 'Captured on the Highlands base miles expedition',
+    icon: Medal,
+  },
+  {
+    title: 'Sprint Closer',
+    description: 'Executed back-to-back 15-second sprints above 1300 watts deep into a training crit.',
+    metricHighlight: 'Peak late-ride neuromuscular output',
+    activity: 'Sealed in the Riverside twilight criterium',
+    icon: Crown,
+  },
+  {
+    title: 'Climb Consistency Laureate',
+    description: 'Matched pacing within 2% variance across all switchbacks of a 45-minute climb effort.',
+    metricHighlight: 'Most stable climb pacing score',
+    activity: 'Logged during the Monte Verde pacing rehearsal',
+    icon: Award,
+  },
+];
+
+type TrophyCaseProps = {
+  className?: string;
+  id?: string;
+};
+
+export function TrophyCase({ className, id }: TrophyCaseProps) {
+  return (
+    <section
+      id={id}
+      className={cn(
+        'space-y-8 rounded-3xl border bg-primary/5 p-8 shadow-lg shadow-primary/5 md:p-12',
+        className,
+      )}
+    >
+      <div className="space-y-3">
+        <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+          Trophy case
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold tracking-tight text-foreground">Showcase of standout rides</h2>
+          <p className="text-sm text-muted-foreground">
+            These highlights surface the rides that unlocked recent trophies. Use them as inspiration for what to
+            chase next or to revisit the files that set new standards for your training.
+          </p>
+        </div>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {trophyHighlights.map((trophy) => (
+          <Card key={trophy.title} className="h-full border-primary/20 bg-background/90">
+            <CardHeader className="flex flex-row items-start gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <trophy.icon className="h-6 w-6" aria-hidden />
+              </div>
+              <div className="space-y-1">
+                <CardTitle className="text-lg font-semibold text-foreground">{trophy.title}</CardTitle>
+                <CardDescription>{trophy.metricHighlight}</CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>{trophy.description}</p>
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary/80">{trophy.activity}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- document the activity behind each achievement and expose a trophy case on the achievements hub
- add anchored sections for the achievement tracker to support deep links
- introduce analytics and achievements dropdown menus in the site header

## Testing
- pnpm --filter web lint
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3d1b1973883309457f7b5b05c4706