### PR TITLE
Fix ride track map normalization for string coordinates

### DIFF
--- a/apps/web/components/ride-track-map.tsx
+++ b/apps/web/components/ride-track-map.tsx
@@ -13,9 +13,25 @@ const VIEWBOX_WIDTH = 800;
 const VIEWBOX_HEIGHT = 600;
 
 function normalizePoints(points: ActivityTrackPoint[]) {
-  const sanitized = points.filter(
-    (point) => Number.isFinite(point.latitude) && Number.isFinite(point.longitude),
-  );
+  const sanitized: Array<{ latitude: number; longitude: number }> = points
+    .map((point) => {
+      const latitude = typeof point.latitude === 'number'
+        ? point.latitude
+        : point.latitude != null
+          ? Number.parseFloat(String(point.latitude))
+          : null;
+      const longitude = typeof point.longitude === 'number'
+        ? point.longitude
+        : point.longitude != null
+          ? Number.parseFloat(String(point.longitude))
+          : null;
+
+      return { latitude, longitude };
+    })
+    .filter(
+      (point): point is { latitude: number; longitude: number } =>
+        Number.isFinite(point.latitude) && Number.isFinite(point.longitude),
+    );
 
   if (sanitized.length === 0) {
     return [] as Array<[number, number]>;


### PR DESCRIPTION
## Summary
- allow ride track map normalization to coerce string latitude and longitude values into numbers
- keep valid GPS points when Prisma returns coordinates as numeric strings so the SVG path renders

## Testing
- pnpm --filter web lint
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e479f8dcb0833099909bbc00289caf