### PR TITLE
Refine ride map rendering and metadata

### DIFF
--- a/apps/web/components/activity-detail-client.tsx
+++ b/apps/web/components/activity-detail-client.tsx
@@ -16,6 +16,7 @@ import type {
   IntervalEfficiencyResponse,
   MetricResultDetail,
   ActivityTrackPoint,
+  ActivityTrackResponse,
 } from '../types/activity';
 import { HcsrChart } from './hcsr-chart';
 import { IntervalEfficiencyChart } from './interval-efficiency-chart';
@@ -195,6 +196,7 @@ export function ActivityDetailClient({
     initialLateAerobicEfficiency,
   );
   const [trackPoints, setTrackPoints] = useState<ActivityTrackPoint[]>([]);
+  const [trackBounds, setTrackBounds] = useState<ActivityTrackResponse['bounds'] | null>(null);
   const [trackError, setTrackError] = useState<string | null>(null);
   const [isTrackLoading, setIsTrackLoading] = useState<boolean>(true);
 
@@ -368,6 +370,7 @@ export function ActivityDetailClient({
     let cancelled = false;
     setIsTrackLoading(true);
     setTrackError(null);
+    setTrackBounds(null);
 
     fetchActivityTrack(activity.id, session?.accessToken)
       .then((response) => {
@@ -376,6 +379,7 @@ export function ActivityDetailClient({
         }
         setTrackPoints(response.points);
         setTrackError(null);
+        setTrackBounds(response.bounds);
       })
       .catch((err) => {
         if (cancelled) {
@@ -388,6 +392,7 @@ export function ActivityDetailClient({
           setTrackError(message);
         }
         setTrackPoints([]);
+        setTrackBounds(null);
       })
       .finally(() => {
         if (!cancelled) {
@@ -443,7 +448,7 @@ export function ActivityDetailClient({
               {trackError}
             </div>
           ) : trackPoints.length > 0 ? (
-            <RideTrackMap points={trackPoints} className="h-full w-full" />
+            <RideTrackMap points={trackPoints} bounds={trackBounds ?? undefined} className="h-full w-full" />
           ) : (
             <div className="flex h-full items-center justify-center px-4 text-sm text-muted-foreground">
               No GPS data available for this ride.

--- a/apps/web/components/ride-track-map.tsx
+++ b/apps/web/components/ride-track-map.tsx
@@ -2,16 +2,36 @@
 
 import { useMemo } from 'react';
 
-import type { ActivityTrackPoint } from '../types/activity';
+import type { ActivityTrackPoint, ActivityTrackResponse } from '../types/activity';
 import { cn } from '../lib/utils';
 
 interface RideTrackMapProps {
   points: ActivityTrackPoint[];
+  bounds?: ActivityTrackResponse['bounds'];
   className?: string;
 }
 
 const VIEWBOX_WIDTH = 800;
 const VIEWBOX_HEIGHT = 600;
+
+interface SanitizedPoint {
+  latitude: number;
+  longitude: number;
+}
+
+interface PreparedTrack {
+  normalized: Array<[number, number]>;
+  path: string;
+  start: [number, number] | null;
+  finish: [number, number] | null;
+  stats: TrackStats;
+}
+
+interface TrackStats {
+  latSpanDeg: number;
+  lonSpanDeg: number;
+  approxDistanceKm: number | null;
+}
 
 function coerceCoordinate(value: unknown): number | null {
   if (typeof value === 'number') {
@@ -64,34 +84,116 @@ function coerceCoordinate(value: unknown): number | null {
   return null;
 }
 
-function normalizePoints(points: ActivityTrackPoint[]) {
-  const sanitized: Array<{ latitude: number; longitude: number }> = points
+function sanitizePoints(points: ActivityTrackPoint[]): SanitizedPoint[] {
+  return points
     .map((point) => {
       if (!point || typeof point !== 'object') {
         return null;
       }
-
       const latitude = coerceCoordinate((point as ActivityTrackPoint).latitude);
       const longitude = coerceCoordinate((point as ActivityTrackPoint).longitude);
-
       if (latitude == null || longitude == null) {
         return null;
       }
-
       return { latitude, longitude };
     })
-    .filter((point): point is { latitude: number; longitude: number } => point !== null);
+    .filter((point): point is SanitizedPoint => point !== null);
+}
 
-  if (sanitized.length === 0) {
-    return [] as Array<[number, number]>;
+function unwrapLongitudes(points: SanitizedPoint[]): SanitizedPoint[] {
+  if (points.length === 0) {
+    return points;
   }
+
+  const unwrapped: SanitizedPoint[] = [];
+  let offset = 0;
+  let previous = points[0]!.longitude;
+  for (const point of points) {
+    let longitude = point.longitude + offset;
+    const adjustedPrevious = previous + offset;
+    const delta = longitude - adjustedPrevious;
+    if (delta > 180) {
+      offset -= 360;
+      longitude = point.longitude + offset;
+    } else if (delta < -180) {
+      offset += 360;
+      longitude = point.longitude + offset;
+    }
+    unwrapped.push({ latitude: point.latitude, longitude });
+    previous = point.longitude;
+  }
+  return unwrapped;
+}
+
+function degreesToRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
+}
+
+function haversineDistanceKm(a: SanitizedPoint, b: SanitizedPoint): number {
+  const R = 6371; // km
+  const lat1 = degreesToRadians(a.latitude);
+  const lat2 = degreesToRadians(b.latitude);
+  const dLat = lat2 - lat1;
+  let dLon = degreesToRadians(b.longitude - a.longitude);
+  if (dLon > Math.PI) {
+    dLon -= 2 * Math.PI;
+  } else if (dLon < -Math.PI) {
+    dLon += 2 * Math.PI;
+  }
+  const sinLat = Math.sin(dLat / 2);
+  const sinLon = Math.sin(dLon / 2);
+  const h = sinLat * sinLat + Math.cos(lat1) * Math.cos(lat2) * sinLon * sinLon;
+  const c = 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+  return R * c;
+}
+
+function computeTrackStats(points: SanitizedPoint[]): TrackStats {
+  if (points.length === 0) {
+    return { latSpanDeg: 0, lonSpanDeg: 0, approxDistanceKm: null };
+  }
+  const unwrapped = unwrapLongitudes(points);
+  let minLat = Number.POSITIVE_INFINITY;
+  let maxLat = Number.NEGATIVE_INFINITY;
+  let minLon = Number.POSITIVE_INFINITY;
+  let maxLon = Number.NEGATIVE_INFINITY;
+  for (const point of unwrapped) {
+    minLat = Math.min(minLat, point.latitude);
+    maxLat = Math.max(maxLat, point.latitude);
+    minLon = Math.min(minLon, point.longitude);
+    maxLon = Math.max(maxLon, point.longitude);
+  }
+  let distance = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    distance += haversineDistanceKm(points[index - 1]!, points[index]!);
+  }
+  return {
+    latSpanDeg: maxLat - minLat,
+    lonSpanDeg: maxLon - minLon,
+    approxDistanceKm: Number.isFinite(distance) ? distance : null,
+  };
+}
+
+function prepareTrack(points: ActivityTrackPoint[]): PreparedTrack {
+  const sanitized = sanitizePoints(points);
+  if (sanitized.length === 0) {
+    return {
+      normalized: [],
+      path: '',
+      start: null,
+      finish: null,
+      stats: { latSpanDeg: 0, lonSpanDeg: 0, approxDistanceKm: null },
+    };
+  }
+
+  const unwrapped = unwrapLongitudes(sanitized);
+  const stats = computeTrackStats(sanitized);
 
   let minLat = Number.POSITIVE_INFINITY;
   let maxLat = Number.NEGATIVE_INFINITY;
   let minLon = Number.POSITIVE_INFINITY;
   let maxLon = Number.NEGATIVE_INFINITY;
 
-  for (const point of sanitized) {
+  for (const point of unwrapped) {
     minLat = Math.min(minLat, point.latitude);
     maxLat = Math.max(maxLat, point.latitude);
     minLon = Math.min(minLon, point.longitude);
@@ -99,85 +201,162 @@ function normalizePoints(points: ActivityTrackPoint[]) {
   }
 
   const latRange = Math.max(maxLat - minLat, 1e-6);
-  const midLatitudeRadians = ((maxLat + minLat) / 2) * (Math.PI / 180);
-  // Longitude degrees shrink by cos(latitude); adjust so tracks keep their aspect ratio.
-  const lonToLatRatio = Math.max(Math.abs(Math.cos(midLatitudeRadians)), 1e-6);
-  const lonRange = Math.max((maxLon - minLon) * lonToLatRatio, 1e-6);
+  const midLatitudeRadians = degreesToRadians((maxLat + minLat) / 2);
+  const lonScaleFactor = Math.max(Math.abs(Math.cos(midLatitudeRadians)), 1e-6);
+  const lonRange = Math.max((maxLon - minLon) * lonScaleFactor, 1e-6);
   const scale = Math.min(VIEWBOX_WIDTH / lonRange, VIEWBOX_HEIGHT / latRange);
   const offsetX = (VIEWBOX_WIDTH - lonRange * scale) / 2;
   const offsetY = (VIEWBOX_HEIGHT - latRange * scale) / 2;
 
-  return sanitized.map((point) => {
-    const projectedLon = (point.longitude - minLon) * lonToLatRatio;
+  const normalized = unwrapped.map((point) => {
+    const projectedLon = (point.longitude - minLon) * lonScaleFactor;
     const x = projectedLon * scale + offsetX;
     const y = VIEWBOX_HEIGHT - ((point.latitude - minLat) * scale + offsetY);
     return [Number.parseFloat(x.toFixed(2)), Number.parseFloat(y.toFixed(2))] as [number, number];
   });
+
+  const path = normalized
+    .map(([x, y], index) => `${index === 0 ? 'M' : 'L'}${x} ${y}`)
+    .join(' ');
+
+  return {
+    normalized,
+    path,
+    start: normalized[0] ?? null,
+    finish: normalized[normalized.length - 1] ?? null,
+    stats,
+  };
 }
 
-export function RideTrackMap({ points, className }: RideTrackMapProps) {
-  const normalized = useMemo(() => normalizePoints(points), [points]);
-  const hasRoute = normalized.length > 0;
+function formatSpan(value: number, fractionDigits = 2) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return '—';
+  }
+  if (value >= 1) {
+    return `${value.toFixed(fractionDigits)}°`;
+  }
+  const minutes = value * 60;
+  if (minutes >= 1) {
+    return `${minutes.toFixed(fractionDigits)}′`;
+  }
+  return `${(minutes * 60).toFixed(fractionDigits)}″`;
+}
 
-  const pathData = useMemo(() => {
-    if (!hasRoute) {
-      return '';
+function formatDistance(kilometers: number | null) {
+  if (kilometers == null || !Number.isFinite(kilometers) || kilometers <= 0) {
+    return 'Distance unavailable';
+  }
+  if (kilometers >= 1) {
+    return `${kilometers.toFixed(1)} km of samples`;
+  }
+  return `${(kilometers * 1000).toFixed(0)} m of samples`;
+}
+
+export function RideTrackMap({ points, bounds, className }: RideTrackMapProps) {
+  const prepared = useMemo(() => prepareTrack(points), [points]);
+  const hasRoute = prepared.normalized.length > 0;
+
+  const latSpanText = useMemo(() => formatSpan(prepared.stats.latSpanDeg), [prepared.stats.latSpanDeg]);
+  const lonSpanText = useMemo(() => formatSpan(prepared.stats.lonSpanDeg), [prepared.stats.lonSpanDeg]);
+  const distanceText = useMemo(() => formatDistance(prepared.stats.approxDistanceKm), [
+    prepared.stats.approxDistanceKm,
+  ]);
+
+  const boundsText = useMemo(() => {
+    if (!bounds) {
+      return null;
     }
-    const commands = normalized.map(([x, y], index) => {
-      return `${index === 0 ? 'M' : 'L'}${x} ${y}`;
-    });
-    return commands.join(' ');
-  }, [hasRoute, normalized]);
-
-  const start = hasRoute ? normalized[0] : null;
-  const finish = hasRoute ? normalized[normalized.length - 1] : null;
+    const north = bounds.maxLatitude;
+    const south = bounds.minLatitude;
+    const east = bounds.maxLongitude;
+    const west = bounds.minLongitude;
+    const latSummary = `${Math.abs(north).toFixed(3)}°${north >= 0 ? 'N' : 'S'} / ${Math.abs(south).toFixed(3)}°${south >= 0 ? 'N' : 'S'}`;
+    const lonSummary = `${Math.abs(east).toFixed(3)}°${east >= 0 ? 'E' : 'W'} / ${Math.abs(west).toFixed(3)}°${west >= 0 ? 'E' : 'W'}`;
+    return { latSummary, lonSummary };
+  }, [bounds]);
 
   return (
-    <div className={cn('relative', className)}>
+    <div className={cn('relative overflow-hidden rounded-3xl border border-slate-800/40', className)}>
       <svg viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`} className="h-full w-full">
         <defs>
           <linearGradient id="ride-map-bg" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#0f172a" />
-            <stop offset="50%" stopColor="#1d4ed8" />
-            <stop offset="100%" stopColor="#9333ea" />
+            <stop offset="0%" stopColor="#020617" />
+            <stop offset="50%" stopColor="#1e293b" />
+            <stop offset="100%" stopColor="#0f172a" />
           </linearGradient>
-          <linearGradient id="ride-map-path" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop offset="0%" stopColor="#bef264" />
+          <linearGradient id="ride-map-path" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="#34d399" />
             <stop offset="50%" stopColor="#38bdf8" />
             <stop offset="100%" stopColor="#f97316" />
           </linearGradient>
           <filter id="ride-map-glow" x="-50%" y="-50%" width="200%" height="200%">
-            <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur" />
+            <feGaussianBlur in="SourceGraphic" stdDeviation="7" result="blur" />
             <feMerge>
               <feMergeNode in="blur" />
               <feMergeNode in="SourceGraphic" />
             </feMerge>
           </filter>
+          <pattern id="ride-map-grid" width="80" height="80" patternUnits="userSpaceOnUse">
+            <path d={`M 80 0 L 0 0 0 80`} fill="none" stroke="#64748b" strokeOpacity="0.12" strokeWidth="1" />
+          </pattern>
         </defs>
-        <rect width="100%" height="100%" fill="url(#ride-map-bg)" rx="24" />
-        <g opacity="0.15" stroke="#e2e8f0" strokeWidth="1">
-          {Array.from({ length: 10 }).map((_, index) => {
-            const x = ((index + 1) / 11) * VIEWBOX_WIDTH;
-            return <line key={`v-${index}`} x1={x} y1={0} x2={x} y2={VIEWBOX_HEIGHT} />;
-          })}
-          {Array.from({ length: 6 }).map((_, index) => {
-            const y = ((index + 1) / 7) * VIEWBOX_HEIGHT;
-            return <line key={`h-${index}`} x1={0} y1={y} x2={VIEWBOX_WIDTH} y2={y} />;
-          })}
-        </g>
-        {hasRoute && pathData ? (
+        <rect width="100%" height="100%" fill="url(#ride-map-bg)" />
+        <rect width="100%" height="100%" fill="url(#ride-map-grid)" />
+        {hasRoute && prepared.path ? (
           <g filter="url(#ride-map-glow)">
-            <path d={pathData} fill="none" stroke="url(#ride-map-path)" strokeWidth="10" strokeLinecap="round" />
+            <path
+              d={prepared.path}
+              fill="none"
+              stroke="url(#ride-map-path)"
+              strokeWidth={12}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </g>
         ) : null}
-        {start ? <circle cx={start[0]} cy={start[1]} r={14} fill="#f97316" opacity="0.9" /> : null}
-        {finish ? <circle cx={finish[0]} cy={finish[1]} r={14} fill="#38bdf8" opacity="0.9" /> : null}
+        {hasRoute && prepared.start ? (
+          <circle cx={prepared.start[0]} cy={prepared.start[1]} r={14} fill="#f97316" opacity="0.9" />
+        ) : null}
+        {hasRoute && prepared.finish ? (
+          <circle cx={prepared.finish[0]} cy={prepared.finish[1]} r={14} fill="#38bdf8" opacity="0.9" />
+        ) : null}
       </svg>
       {!hasRoute ? (
-        <div className="absolute inset-0 flex items-center justify-center px-4 text-sm text-slate-200">
+        <div className="absolute inset-0 flex items-center justify-center bg-slate-950/60 px-4 text-sm text-slate-200">
           No valid GPS samples were found for this ride.
         </div>
-      ) : null}
+      ) : (
+        <>
+          <div className="pointer-events-none absolute inset-x-4 bottom-4 flex flex-col gap-2 rounded-2xl bg-slate-950/70 p-4 text-[0.7rem] text-slate-200 shadow-lg shadow-primary/10 backdrop-blur">
+            <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+              <span>Route summary</span>
+              <span className="tracking-normal text-slate-100">{distanceText}</span>
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-[0.75rem]">
+              <div className="flex flex-col gap-1">
+                <span className="text-xs uppercase tracking-[0.2em] text-slate-400">Latitude span</span>
+                <span className="text-base font-semibold text-slate-100">{latSpanText}</span>
+              </div>
+              <div className="flex flex-col gap-1">
+                <span className="text-xs uppercase tracking-[0.2em] text-slate-400">Longitude span</span>
+                <span className="text-base font-semibold text-slate-100">{lonSpanText}</span>
+              </div>
+            </div>
+            {boundsText ? (
+              <div className="grid grid-cols-2 gap-3 text-[0.75rem] text-slate-300">
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs uppercase tracking-[0.2em] text-slate-500">Lat bounds</span>
+                  <span className="font-medium text-slate-100">{boundsText.latSummary}</span>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs uppercase tracking-[0.2em] text-slate-500">Lon bounds</span>
+                  <span className="font-medium text-slate-100">{boundsText.lonSummary}</span>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- capture track bounds when loading activity tracks and supply them to the ride map
- rebuild the ride map component to unwrap longitudes, normalise points more robustly, and display route metadata overlays
- refresh the SVG styling so the path glow, grid, and start/finish markers remain visible even with challenging GPS data

## Testing
- pnpm --filter web lint
- pnpm --filter backend lint *(fails: existing import/order violations in backend services)*

------
https://chatgpt.com/codex/tasks/task_e_68e48c3d2d448330abd8917f1761f676