### PR TITLE
Add interactive Leaflet ride map

### DIFF
--- a/apps/web/lib/load-leaflet.ts
+++ b/apps/web/lib/load-leaflet.ts
@@ -1,0 +1,80 @@
+'use client';
+
+const LEAFLET_SCRIPT_SRC = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+const LEAFLET_STYLESHEET_HREF = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+
+function ensureStylesheet(documentRef: Document) {
+  if (documentRef.querySelector('link[data-leaflet="stylesheet"]')) {
+    return;
+  }
+
+  const link = documentRef.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = LEAFLET_STYLESHEET_HREF;
+  link.setAttribute('data-leaflet', 'stylesheet');
+  documentRef.head.append(link);
+}
+
+function ensureScript(documentRef: Document): Promise<typeof window.L> {
+  if (typeof window.L !== 'undefined') {
+    return Promise.resolve(window.L);
+  }
+
+  if (window.__leafletLoaderPromise) {
+    return window.__leafletLoaderPromise;
+  }
+
+  window.__leafletLoaderPromise = new Promise((resolve, reject) => {
+    const existingScript = documentRef.querySelector('script[data-leaflet="script"]');
+    if (existingScript) {
+      existingScript.addEventListener('load', () => {
+        if (typeof window.L !== 'undefined') {
+          resolve(window.L);
+        } else {
+          reject(new Error('Leaflet failed to initialize.'));
+        }
+      });
+      existingScript.addEventListener('error', () => {
+        reject(new Error('Failed to load Leaflet script.'));
+      });
+      return;
+    }
+
+    const script = documentRef.createElement('script');
+    script.src = LEAFLET_SCRIPT_SRC;
+    script.async = true;
+    script.setAttribute('data-leaflet', 'script');
+
+    script.addEventListener('load', () => {
+      if (typeof window.L !== 'undefined') {
+        resolve(window.L);
+      } else {
+        reject(new Error('Leaflet failed to initialize.'));
+      }
+    });
+
+    script.addEventListener('error', () => {
+      reject(new Error('Failed to load Leaflet script.'));
+    });
+
+    documentRef.head.append(script);
+  });
+
+  return window.__leafletLoaderPromise;
+}
+
+export async function loadLeaflet(): Promise<typeof window.L> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    throw new Error('Leaflet can only be loaded in the browser.');
+  }
+
+  ensureStylesheet(document);
+  return ensureScript(document);
+}
+
+declare global {
+  interface Window {
+    L: any;
+    __leafletLoaderPromise?: Promise<typeof window.L>;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the canvas-based ride map with an interactive Leaflet map that supports zooming and panning
- render OpenStreetMap tiles, the ride polyline, and start/finish markers while keeping the previous no-GPS fallback
- add a small client-side loader that injects the Leaflet script and stylesheet from a CDN

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68e49a01aacc833085d5ba3b52787f3c