### PR TITLE
Ensure API endpoints use explicit status codes

### DIFF
--- a/apps/backend/src/routes/activities.ts
+++ b/apps/backend/src/routes/activities.ts
@@ -107,7 +107,7 @@ activitiesRouter.get(
       prisma.activity.count({ where: userId ? { userId } : undefined }),
     ]);
 
-    res.json({
+    res.status(200).json({
       data: activities.map(mapActivity),
       page: params.page,
       pageSize: params.pageSize,
@@ -140,7 +140,7 @@ activitiesRouter.get(
       return;
     }
 
-    res.json(mapActivity(activity));
+    res.status(200).json(mapActivity(activity));
   }),
 );
 
@@ -202,7 +202,7 @@ activitiesRouter.get(
     const latitudes = simplified.map((point) => point.latitude);
     const longitudes = simplified.map((point) => point.longitude);
 
-    res.json({
+    res.status(200).json({
       points: simplified.map((point) => {
         const base = { lat: point.latitude, lon: point.longitude } as {
           lat: number;
@@ -253,7 +253,7 @@ activitiesRouter.get(
       power: typeof sample.power === 'number' && Number.isFinite(sample.power) ? sample.power : null,
     }));
 
-    res.json({ samples: formatted });
+    res.status(200).json({ samples: formatted });
   }),
 );
 
@@ -269,7 +269,7 @@ activitiesRouter.post(
     const metricKeys = body?.metricKeys;
 
     const results = await runMetrics(req.params.id, metricKeys ?? undefined, req.user?.id);
-    res.json({ activityId: req.params.id, results });
+    res.status(200).json({ activityId: req.params.id, results });
   }),
 );
 
@@ -297,7 +297,7 @@ activitiesRouter.get(
     const summary = metricResult.summary as Record<string, unknown>;
     const intervals = normalizeIntervalEfficiencySeries(metricResult.series);
 
-    res.json({
+    res.status(200).json({
       intervals,
       intervalSeconds:
         typeof summary.interval_seconds === 'number'
@@ -330,7 +330,7 @@ activitiesRouter.get(
       return;
     }
 
-    res.json({
+    res.status(200).json({
       key: metricResult.metricDefinition.key,
       definition: metricResult.metricDefinition,
       summary: metricResult.summary,

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -42,7 +42,7 @@ authRouter.post(
 
     try {
       const result = await authenticateUser(email.toLowerCase(), password);
-      res.json(result);
+      res.status(200).json(result);
     } catch (error) {
       res.status(401).json({ error: (error as Error).message });
     }

--- a/apps/backend/src/routes/durabilityAnalysis.ts
+++ b/apps/backend/src/routes/durabilityAnalysis.ts
@@ -78,6 +78,6 @@ durabilityAnalysisRouter.get(
     const userId = req.user!.id;
     const analysis = await getDurabilityAnalysis(userId, filters);
 
-    res.json(analysis);
+    res.status(200).json(analysis);
   }),
 );

--- a/apps/backend/src/routes/durableTss.ts
+++ b/apps/backend/src/routes/durableTss.ts
@@ -93,6 +93,6 @@ durableTssRouter.get(
     const userId = req.user!.id;
     const response = await getDurableTss(userId, filters);
 
-    res.json(response);
+    res.status(200).json(response);
   }),
 );

--- a/apps/backend/src/routes/metrics.ts
+++ b/apps/backend/src/routes/metrics.ts
@@ -29,7 +29,7 @@ type IntervalEfficiencyHistoryRow = {
 export const metricsRouter = express.Router();
 
 metricsRouter.get('/', (_req, res) => {
-  res.json({ definitions: listMetricDefinitions() });
+  res.status(200).json({ definitions: listMetricDefinitions() });
 });
 
 function formatEfficiency(value: number | null): number | null {
@@ -61,7 +61,7 @@ metricsRouter.get(
       })) as IntervalEfficiencyHistoryRow[];
 
       if (metricResults.length === 0) {
-        res.json({
+        res.status(200).json({
           metric: {
             key: 'interval-efficiency',
             name: 'Interval Efficiency',
@@ -131,7 +131,7 @@ metricsRouter.get(
         }];
       });
 
-      res.json({
+      res.status(200).json({
         metric: {
           key: definition.key,
           name: definition.name,
@@ -143,7 +143,8 @@ metricsRouter.get(
       });
     } catch (error) {
       logger.error({ err: error }, 'Failed to load metric history');
-      throw error;
+      res.status(500).json({ error: 'Failed to load metric history.' });
+      return;
     }
   }),
 );
@@ -154,10 +155,11 @@ metricsRouter.get(
     try {
       const userId = req.user?.id;
       const analysis = await computeAdaptationEdges(userId);
-      res.json(analysis);
+      res.status(200).json(analysis);
     } catch (error) {
       logger.error({ err: error }, 'Failed to compute adaptation edges');
-      throw error;
+      res.status(500).json({ error: 'Failed to compute adaptation edges.' });
+      return;
     }
   }),
 );
@@ -168,10 +170,11 @@ metricsRouter.get(
     try {
       const userId = req.user?.id;
       const days = await computeMovingAverageInputs(userId);
-      res.json({ days });
+      res.status(200).json({ days });
     } catch (error) {
       logger.error({ err: error }, 'Failed to compute moving averages');
-      throw error;
+      res.status(500).json({ error: 'Failed to compute moving averages.' });
+      return;
     }
   }),
 );
@@ -192,10 +195,11 @@ metricsRouter.get(
         minPowerWatts: safeMinPower,
       });
 
-      res.json(analysis);
+      res.status(200).json(analysis);
     } catch (error) {
       logger.error({ err: error }, 'Failed to compute depth analysis');
-      throw error;
+      res.status(500).json({ error: 'Failed to compute depth analysis.' });
+      return;
     }
   }),
 );

--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -130,13 +130,13 @@ profileRouter.get(
 
     const userId = req.user?.id;
     if (!userId) {
-      res.json(null);
+      res.status(200).json(null);
       return;
     }
 
     const profile = await getOrCreateProfile(userId);
 
-    res.json(profile);
+    res.status(200).json(profile);
   }),
 );
 
@@ -184,17 +184,17 @@ profileRouter.put(
 
     if (!existing) {
       const created = await prisma.profile.create({ data: { userId, ...updateData } });
-      res.json(created);
+      res.status(200).json(created);
       return;
     }
 
     if (Object.keys(updateData).length === 0) {
-      res.json(existing);
+      res.status(200).json(existing);
       return;
     }
 
     const updated = await prisma.profile.update({ where: { userId }, data: updateData });
 
-    res.json(updated);
+    res.status(200).json(updated);
   }),
 );

--- a/apps/backend/src/routes/trainingFrontiers.ts
+++ b/apps/backend/src/routes/trainingFrontiers.ts
@@ -17,6 +17,6 @@ trainingFrontiersRouter.get(
     const windowDays = typeof windowParam === 'string' ? Number(windowParam) : undefined;
 
     const response = await getTrainingFrontiers(req.user.id, windowDays);
-    res.json(response);
+    res.status(200).json(response);
   }),
 );


### PR DESCRIPTION
## Summary
- return successful responses from activities, durability, durable TSS, profile, and training frontier routes with explicit 200 status codes
- update authentication login and metrics routes to include explicit success statuses and clear 500-level error payloads
- ensure metrics-related endpoints respond deterministically with descriptive error messages when exceptions occur

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5113b008083309ca80df207d3d344