### PR TITLE
Add shimmer loading skeletons to async pages

### DIFF
--- a/apps/web/app/activities/[id]/loading.tsx
+++ b/apps/web/app/activities/[id]/loading.tsx
@@ -1,0 +1,26 @@
+import { CardSkeleton, ChartSkeleton, TableSkeleton } from '../../../components/loading-skeletons';
+import { Skeleton } from '../../../components/ui/skeleton';
+
+export default function ActivityDetailLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-44" />
+        </div>
+        <Skeleton className="h-10 w-40" />
+      </div>
+      <CardSkeleton headerLines={1} bodyHeight="h-[380px]" />
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <CardSkeleton key={index} headerLines={2} bodyLines={5} />
+        ))}
+      </div>
+      <CardSkeleton headerLines={2} bodyLines={6} />
+      <TableSkeleton columns={6} rows={6} />
+      <ChartSkeleton height="h-72" />
+      <CardSkeleton headerLines={2} bodyLines={4} />
+    </div>
+  );
+}

--- a/apps/web/app/activities/loading.tsx
+++ b/apps/web/app/activities/loading.tsx
@@ -1,0 +1,15 @@
+import { MiniStatSkeleton, PageHeaderSkeleton, TableSkeleton } from '../../components/loading-skeletons';
+
+export default function ActivitiesLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <MiniStatSkeleton key={index} />
+        ))}
+      </div>
+      <TableSkeleton columns={6} rows={7} />
+    </div>
+  );
+}

--- a/apps/web/app/activities/trends/loading.tsx
+++ b/apps/web/app/activities/trends/loading.tsx
@@ -1,0 +1,10 @@
+import { ChartSkeleton, PageHeaderSkeleton } from '../../../components/loading-skeletons';
+
+export default function ActivityTrendsLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <ChartSkeleton height="h-[420px]" />
+    </div>
+  );
+}

--- a/apps/web/app/durability-analysis/loading.tsx
+++ b/apps/web/app/durability-analysis/loading.tsx
@@ -1,0 +1,16 @@
+import { CardSkeleton, ChartSkeleton, PageHeaderSkeleton, TableSkeleton } from '../../components/loading-skeletons';
+
+export default function DurabilityAnalysisLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+        <CardSkeleton headerLines={2} bodyLines={6} />
+        <div className="space-y-4">
+          <ChartSkeleton height="h-[360px]" />
+          <TableSkeleton columns={6} rows={6} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/durable-tss/loading.tsx
+++ b/apps/web/app/durable-tss/loading.tsx
@@ -1,0 +1,13 @@
+import { CardSkeleton, ChartSkeleton, PageHeaderSkeleton } from '../../components/loading-skeletons';
+
+export default function DurableTssLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+        <CardSkeleton headerLines={2} bodyLines={4} />
+        <ChartSkeleton height="h-[420px]" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/metrics/(tabs)/adaptation/loading.tsx
+++ b/apps/web/app/metrics/(tabs)/adaptation/loading.tsx
@@ -1,0 +1,14 @@
+import { CardSkeleton, PageHeaderSkeleton } from '../../../../components/loading-skeletons';
+
+export default function AdaptationLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 lg:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <CardSkeleton key={index} headerLines={2} bodyLines={6} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/metrics/(tabs)/depth-analysis/loading.tsx
+++ b/apps/web/app/metrics/(tabs)/depth-analysis/loading.tsx
@@ -1,0 +1,12 @@
+import { CardSkeleton, ChartSkeleton, PageHeaderSkeleton, TableSkeleton } from '../../../../components/loading-skeletons';
+
+export default function DepthAnalysisLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <CardSkeleton headerLines={2} bodyLines={4} />
+      <ChartSkeleton height="h-[360px]" />
+      <TableSkeleton columns={5} rows={5} />
+    </div>
+  );
+}

--- a/apps/web/app/metrics/(tabs)/interval-efficiency/loading.tsx
+++ b/apps/web/app/metrics/(tabs)/interval-efficiency/loading.tsx
@@ -1,0 +1,12 @@
+import { CardSkeleton, ChartSkeleton, PageHeaderSkeleton, TableSkeleton } from '../../../../components/loading-skeletons';
+
+export default function IntervalEfficiencyLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <CardSkeleton headerLines={2} bodyLines={3} />
+      <ChartSkeleton height="h-[360px]" />
+      <TableSkeleton columns={6} rows={6} />
+    </div>
+  );
+}

--- a/apps/web/app/metrics/(tabs)/kj-in-interval/loading.tsx
+++ b/apps/web/app/metrics/(tabs)/kj-in-interval/loading.tsx
@@ -1,0 +1,16 @@
+import { CardSkeleton, ChartSkeleton, PageHeaderSkeleton, TableSkeleton } from '../../../../components/loading-skeletons';
+
+export default function KjInIntervalLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 xl:grid-cols-[340px_1fr]">
+        <CardSkeleton headerLines={2} bodyLines={5} />
+        <div className="space-y-4">
+          <ChartSkeleton height="h-[360px]" />
+          <TableSkeleton columns={5} rows={6} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/metrics/(tabs)/registry/loading.tsx
+++ b/apps/web/app/metrics/(tabs)/registry/loading.tsx
@@ -1,0 +1,16 @@
+import { CardSkeleton, PageHeaderSkeleton, TableSkeleton } from '../../../../components/loading-skeletons';
+
+export default function MetricRegistryLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <CardSkeleton headerLines={1} bodyLines={3} />
+      <div className="grid gap-4 lg:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <CardSkeleton key={index} headerLines={2} bodyLines={5} />
+        ))}
+      </div>
+      <TableSkeleton columns={2} rows={4} />
+    </div>
+  );
+}

--- a/apps/web/app/moving-averages/loading.tsx
+++ b/apps/web/app/moving-averages/loading.tsx
@@ -1,0 +1,14 @@
+import { ChartSkeleton, PageHeaderSkeleton } from '../../components/loading-skeletons';
+
+export default function MovingAveragesLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 lg:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, index) => (
+          <ChartSkeleton key={index} height="h-[360px]" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/profile/loading.tsx
+++ b/apps/web/app/profile/loading.tsx
@@ -1,0 +1,10 @@
+import { FormSkeleton, PageHeaderSkeleton } from '../../components/loading-skeletons';
+
+export default function ProfileLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <FormSkeleton includeAvatar fieldCount={5} />
+    </div>
+  );
+}

--- a/apps/web/app/training-frontiers/loading.tsx
+++ b/apps/web/app/training-frontiers/loading.tsx
@@ -1,0 +1,21 @@
+import { CardSkeleton, ChartSkeleton, PageHeaderSkeleton, TableSkeleton } from '../../components/loading-skeletons';
+
+export default function TrainingFrontiersLoading() {
+  return (
+    <div className="space-y-10">
+      <PageHeaderSkeleton />
+      <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+        <CardSkeleton headerLines={2} bodyLines={5} />
+        <div className="space-y-4">
+          <ChartSkeleton height="h-[360px]" />
+          <div className="grid gap-4 xl:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <CardSkeleton key={index} headerLines={2} bodyLines={5} />
+            ))}
+          </div>
+          <TableSkeleton columns={5} rows={5} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/loading-skeletons.tsx
+++ b/apps/web/components/loading-skeletons.tsx
@@ -1,0 +1,207 @@
+import { cn } from '../lib/utils';
+import { Skeleton } from './ui/skeleton';
+
+export function PageHeaderSkeleton({
+  align = 'left',
+  descriptionLines = 2,
+  eyebrow = false,
+  className,
+}: {
+  align?: 'left' | 'center';
+  descriptionLines?: number;
+  eyebrow?: boolean;
+  className?: string;
+}) {
+  const isCentered = align === 'center';
+  const descriptionCount = Math.max(0, descriptionLines);
+
+  return (
+    <div className={cn('space-y-4', isCentered ? 'text-center' : 'text-left', className)}>
+      {eyebrow ? (
+        <Skeleton
+          className={cn(
+            'h-5 w-32 rounded-full',
+            isCentered ? 'mx-auto' : undefined,
+          )}
+        />
+      ) : null}
+      <div className={cn('space-y-3', isCentered ? 'mx-auto max-w-2xl' : 'max-w-3xl')}>
+        <Skeleton
+          className={cn(
+            'h-9 w-3/4 sm:w-2/3',
+            isCentered ? 'mx-auto' : undefined,
+          )}
+        />
+        {Array.from({ length: descriptionCount }).map((_, index) => (
+          <Skeleton
+            key={index}
+            className={cn(
+              'h-5',
+              index === descriptionCount - 1 ? 'w-1/2 sm:w-2/3' : 'w-full',
+              isCentered ? 'mx-auto' : undefined,
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function MiniStatSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn('rounded-2xl border bg-card/70 p-5 shadow-sm', className)}>
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="mt-4 h-7 w-16" />
+      <Skeleton className="mt-3 h-3 w-20" />
+    </div>
+  );
+}
+
+export function CardSkeleton({
+  className,
+  headerLines = 2,
+  bodyLines = 4,
+  bodyHeight,
+}: {
+  className?: string;
+  headerLines?: number;
+  bodyLines?: number;
+  bodyHeight?: string;
+}) {
+  const headerCount = Math.max(0, headerLines);
+  const bodyCount = Math.max(0, bodyLines);
+
+  return (
+    <div className={cn('rounded-2xl border bg-card/70 p-6 shadow-sm', className)}>
+      <div className="space-y-4">
+        {headerCount > 0 ? (
+          <div className="space-y-2">
+            {Array.from({ length: headerCount }).map((_, index) => (
+              <Skeleton
+                key={index}
+                className={cn(
+                  'h-5',
+                  index === 0 ? 'w-1/3' : index === headerCount - 1 ? 'w-1/4' : 'w-2/5',
+                )}
+              />
+            ))}
+          </div>
+        ) : null}
+        {bodyHeight ? (
+          <Skeleton className={cn('w-full rounded-xl', bodyHeight)} />
+        ) : (
+          <div className="space-y-2">
+            {Array.from({ length: bodyCount }).map((_, index) => (
+              <Skeleton
+                key={index}
+                className={cn(
+                  'h-4',
+                  index === bodyCount - 1 ? 'w-2/3' : index % 2 === 0 ? 'w-full' : 'w-5/6',
+                )}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ChartSkeleton({
+  className,
+  height = 'h-64',
+  headerLines = 2,
+}: {
+  className?: string;
+  height?: string;
+  headerLines?: number;
+}) {
+  return (
+    <CardSkeleton className={className} headerLines={headerLines} bodyHeight={height} />
+  );
+}
+
+export function TableSkeleton({
+  className,
+  columns = 5,
+  rows = 6,
+}: {
+  className?: string;
+  columns?: number;
+  rows?: number;
+}) {
+  const safeColumns = Math.max(1, columns);
+  const safeRows = Math.max(1, rows);
+
+  return (
+    <div className={cn('overflow-hidden rounded-2xl border bg-card/70 shadow-sm', className)}>
+      <div className="border-b border-border/60 bg-muted/50 px-6 py-3">
+        <div
+          className="grid items-center gap-4"
+          style={{ gridTemplateColumns: `repeat(${safeColumns}, minmax(0, 1fr))` }}
+        >
+          {Array.from({ length: safeColumns }).map((_, index) => (
+            <Skeleton key={index} className="h-4 w-4/5" />
+          ))}
+        </div>
+      </div>
+      <div className="divide-y divide-border/60">
+        {Array.from({ length: safeRows }).map((_, rowIndex) => (
+          <div key={rowIndex} className="px-6 py-4">
+            <div
+              className="grid items-center gap-4"
+              style={{ gridTemplateColumns: `repeat(${safeColumns}, minmax(0, 1fr))` }}
+            >
+              {Array.from({ length: safeColumns }).map((_, colIndex) => (
+                <Skeleton
+                  key={colIndex}
+                  className={cn('h-4', colIndex === safeColumns - 1 ? 'w-1/2' : 'w-4/5')}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function FormSkeleton({
+  className,
+  fieldCount = 4,
+  includeAvatar = false,
+}: {
+  className?: string;
+  fieldCount?: number;
+  includeAvatar?: boolean;
+}) {
+  const safeFields = Math.max(0, fieldCount);
+
+  return (
+    <div className={cn('rounded-2xl border bg-card/70 p-6 shadow-sm', className)}>
+      <div className="space-y-6">
+        {includeAvatar ? (
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-16 w-16 rounded-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          </div>
+        ) : null}
+        <div className="space-y-5">
+          {Array.from({ length: safeFields }).map((_, index) => (
+            <div key={index} className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-24" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -6,7 +6,12 @@ const Skeleton = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEl
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('animate-pulse rounded-md bg-muted', className)}
+      className={cn(
+        'relative overflow-hidden rounded-md bg-muted/70',
+        'before:absolute before:inset-0 before:-translate-x-full before:animate-shimmer',
+        "before:bg-gradient-to-r before:from-transparent before:via-foreground/10 before:to-transparent before:content-['']",
+        className,
+      )}
       {...props}
     />
   ),

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -57,10 +57,15 @@ const config: Config = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: '0' },
         },
+        shimmer: {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(100%)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        shimmer: 'shimmer 1.8s ease-in-out infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add reusable shimmering skeleton utilities and update the base skeleton style
- introduce route-level loading placeholders for each async data page across activities, metrics, durability, and profile sections
- extend Tailwind animations to drive the shimmer effect for the new loading states

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68e51ac13c94833082c792cc0b039718