### PR TITLE
feat: redesign activity trends analytics

### DIFF
--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -10,6 +10,7 @@ import { uploadRouter } from './upload.js';
 import { durabilityAnalysisRouter } from './durabilityAnalysis.js';
 import { durableTssRouter } from './durableTss.js';
 import { trainingFrontiersRouter } from './trainingFrontiers.js';
+import { trendsRouter } from './trends.js';
 
 export const apiRouter = express.Router();
 
@@ -21,3 +22,4 @@ apiRouter.use('/profile', requireAuth, profileRouter);
 apiRouter.use('/durability-analysis', requireAuth, durabilityAnalysisRouter);
 apiRouter.use('/durable-tss', requireAuth, durableTssRouter);
 apiRouter.use('/training-frontiers', requireAuth, trainingFrontiersRouter);
+apiRouter.use('/trends', requireAuth, trendsRouter);

--- a/apps/backend/src/routes/trends.ts
+++ b/apps/backend/src/routes/trends.ts
@@ -1,0 +1,293 @@
+import { Prisma } from '@prisma/client';
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
+
+import { env } from '../env.js';
+import { prisma } from '../prisma.js';
+
+const BUCKETS = ['day', 'week', 'month'] as const;
+const METRICS = ['avg-power', 'avg-hr', 'kilojoules', 'tss', 'durable-tss', 'duration-hours'] as const;
+
+type Bucket = (typeof BUCKETS)[number];
+type Metric = (typeof METRICS)[number];
+
+const querySchema = z.object({
+  metric: z
+    .string()
+    .optional()
+    .refine((value) => value == null || METRICS.includes(value as Metric), {
+      message: `Metric must be one of: ${METRICS.join(', ')}`,
+    })
+    .transform((value) => (value ?? 'avg-power') as Metric),
+  bucket: z
+    .string()
+    .optional()
+    .refine((value) => value == null || BUCKETS.includes(value as Bucket), {
+      message: `Bucket must be one of: ${BUCKETS.join(', ')}`,
+    })
+    .transform((value) => (value ?? 'day') as Bucket),
+  tz: z
+    .string()
+    .optional()
+    .transform((value) => value?.trim() || 'UTC'),
+});
+
+interface TrendRow {
+  bucket: Date;
+  value: number | null;
+  n: bigint;
+}
+
+function resolveTimezone(tz: string): string {
+  if (!tz) {
+    return 'UTC';
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return tz;
+  } catch (error) {
+    return 'UTC';
+  }
+}
+
+function bucketExpression(bucket: Bucket, tz: string) {
+  return Prisma.sql`
+    (DATE_TRUNC(${bucket}, timezone(${tz}, a."startTime")) AT TIME ZONE ${tz})
+  `;
+}
+
+function userFilter(userId: string | null) {
+  if (!userId) {
+    return Prisma.sql`TRUE`;
+  }
+  return Prisma.sql`a."userId" = ${userId}`;
+}
+
+const metricQueries: Record<Metric, (bucket: Bucket, tz: string, userId: string | null) => Prisma.Sql> = {
+  'avg-power': (bucket, tz, userId) => {
+    const bucketExpr = bucketExpression(bucket, tz);
+    return Prisma.sql`
+      WITH activity_power AS (
+        SELECT
+          s."activityId" AS activity_id,
+          AVG(s.power) AS avg_power,
+        FROM "ActivitySample" s
+        WHERE s.power IS NOT NULL
+        GROUP BY s."activityId"
+      )
+      SELECT
+        ${bucketExpr} AS bucket,
+        AVG(activity_power.avg_power) AS value,
+        COUNT(*) AS n
+      FROM activity_power
+      JOIN "Activity" a ON a.id = activity_power.activity_id
+      WHERE ${userFilter(userId)}
+      GROUP BY bucket
+      ORDER BY bucket
+    `;
+  },
+  'avg-hr': (bucket, tz, userId) => {
+    const bucketExpr = bucketExpression(bucket, tz);
+    return Prisma.sql`
+      WITH activity_hr AS (
+        SELECT
+          s."activityId" AS activity_id,
+          AVG(s."heartRate") AS avg_hr
+        FROM "ActivitySample" s
+        WHERE s."heartRate" IS NOT NULL
+        GROUP BY s."activityId"
+      )
+      SELECT
+        ${bucketExpr} AS bucket,
+        AVG(activity_hr.avg_hr) AS value,
+        COUNT(*) AS n
+      FROM activity_hr
+      JOIN "Activity" a ON a.id = activity_hr.activity_id
+      WHERE ${userFilter(userId)}
+      GROUP BY bucket
+      ORDER BY bucket
+    `;
+  },
+  kilojoules: (bucket, tz, userId) => {
+    const bucketExpr = bucketExpression(bucket, tz);
+    return Prisma.sql`
+      WITH activity_power AS (
+        SELECT
+          s."activityId" AS activity_id,
+          AVG(s.power) AS avg_power,
+        FROM "ActivitySample" s
+        WHERE s.power IS NOT NULL
+        GROUP BY s."activityId"
+      )
+      SELECT
+        ${bucketExpr} AS bucket,
+        SUM(activity_power.avg_power * a."durationSec" / 1000.0) AS value,
+        COUNT(*) AS n
+      FROM activity_power
+      JOIN "Activity" a ON a.id = activity_power.activity_id
+      WHERE ${userFilter(userId)}
+      GROUP BY bucket
+      ORDER BY bucket
+    `;
+  },
+  tss: (bucket, tz, userId) => {
+    const bucketExpr = bucketExpression(bucket, tz);
+    return Prisma.sql`
+      WITH profile AS (
+        SELECT
+          p."userId" AS user_id,
+          p."ftpWatts" AS ftp_watts
+        FROM "Profile" p
+      ),
+      activity_power AS (
+        SELECT
+          s."activityId" AS activity_id,
+          AVG(s.power) AS avg_power
+        FROM "ActivitySample" s
+        WHERE s.power IS NOT NULL
+        GROUP BY s."activityId"
+      )
+      SELECT
+        ${bucketExpr} AS bucket,
+        AVG(
+          CASE
+            WHEN COALESCE(profile.ftp_watts, 0) <= 0 THEN NULL
+            ELSE (
+              POWER(activity_power.avg_power / profile.ftp_watts, 2) * (a."durationSec" / 3600.0) * 100
+            )
+          END
+        ) AS value,
+        COUNT(*) FILTER (
+          WHERE COALESCE(profile.ftp_watts, 0) > 0 AND activity_power.avg_power IS NOT NULL
+        ) AS n
+      FROM activity_power
+      JOIN "Activity" a ON a.id = activity_power.activity_id
+      LEFT JOIN profile ON profile.user_id = a."userId"
+      WHERE ${userFilter(userId)}
+      GROUP BY bucket
+      ORDER BY bucket
+    `;
+  },
+  'durable-tss': (bucket, tz, userId) => {
+    const bucketExpr = bucketExpression(bucket, tz);
+    return Prisma.sql`
+      WITH profile AS (
+        SELECT
+          p."userId" AS user_id,
+          p."ftpWatts" AS ftp_watts
+        FROM "Profile" p
+      ),
+      power_samples AS (
+        SELECT
+          s."activityId" AS activity_id,
+          s.power,
+          ROW_NUMBER() OVER (PARTITION BY s."activityId" ORDER BY s.t) AS rn,
+          COUNT(*) OVER (PARTITION BY s."activityId") AS total_samples,
+          SUM(s.power) OVER (PARTITION BY s."activityId" ORDER BY s.t) AS cumulative_power
+        FROM "ActivitySample" s
+        WHERE s.power IS NOT NULL
+      ),
+      threshold_index AS (
+        SELECT
+          ps.activity_id,
+          MIN(ps.rn) FILTER (WHERE ps.cumulative_power >= 1000 * 1000) AS threshold_rn,
+          MAX(ps.total_samples) AS total_samples
+        FROM power_samples ps
+        GROUP BY ps.activity_id
+      ),
+      post_threshold AS (
+        SELECT
+          ps.activity_id,
+          AVG(ps.power) FILTER (WHERE ti.threshold_rn IS NOT NULL AND ps.rn >= ti.threshold_rn) AS avg_power,
+          ti.total_samples,
+          ti.threshold_rn
+        FROM power_samples ps
+        JOIN threshold_index ti ON ti.activity_id = ps.activity_id
+        GROUP BY ps.activity_id, ti.total_samples, ti.threshold_rn
+      )
+      SELECT
+        ${bucketExpr} AS bucket,
+        AVG(
+          CASE
+            WHEN pt.threshold_rn IS NULL THEN NULL
+            WHEN COALESCE(profile.ftp_watts, 0) <= 0 THEN NULL
+            ELSE (
+              POWER(
+                (pt.avg_power) / profile.ftp_watts,
+                2
+              ) * (
+                (a."durationSec" * GREATEST(pt.total_samples - pt.threshold_rn + 1, 0)::numeric / NULLIF(pt.total_samples, 0)) /
+                3600.0 * 100
+              )
+            )
+          END
+        ) AS value,
+        COUNT(*) FILTER (
+          WHERE pt.threshold_rn IS NOT NULL AND COALESCE(profile.ftp_watts, 0) > 0
+        ) AS n
+      FROM post_threshold pt
+      JOIN "Activity" a ON a.id = pt.activity_id
+      LEFT JOIN profile ON profile.user_id = a."userId"
+      WHERE ${userFilter(userId)}
+      GROUP BY bucket
+      ORDER BY bucket
+    `;
+  },
+  'duration-hours': (bucket, tz, userId) => {
+    const bucketExpr = bucketExpression(bucket, tz);
+    return Prisma.sql`
+      SELECT
+        ${bucketExpr} AS bucket,
+        SUM(a."durationSec") / 3600.0 AS value,
+        COUNT(*) AS n
+      FROM "Activity" a
+      WHERE ${userFilter(userId)}
+      GROUP BY bucket
+      ORDER BY bucket
+    `;
+  },
+};
+
+async function runTrendQuery(metric: Metric, bucket: Bucket, tz: string, userId: string | null) {
+  const sql = metricQueries[metric](bucket, tz, userId);
+  return prisma.$queryRaw<TrendRow[]>(sql);
+}
+
+export const trendsRouter = express.Router();
+
+trendsRouter.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    if (env.AUTH_ENABLED && !req.user?.id) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const parsed = querySchema.safeParse(req.query);
+    if (!parsed.success) {
+      const message = parsed.error.errors.at(0)?.message ?? 'Invalid query parameters provided.';
+      res.status(400).json({ error: message });
+      return;
+    }
+
+    const { metric, bucket, tz: tzRaw } = parsed.data;
+    const tz = resolveTimezone(tzRaw);
+    const userId = req.user?.id ?? null;
+
+    const rows = await runTrendQuery(metric, bucket, tz, userId);
+
+    res.status(200).json({
+      metric,
+      bucket,
+      timezone: tz,
+      points: rows.map((row) => ({
+        bucket: row.bucket.toISOString(),
+        value: row.value != null ? Number.parseFloat(row.value.toFixed(3)) : null,
+        n: Number(row.n ?? 0),
+      })),
+    });
+  }),
+);

--- a/apps/web/app/activities/trends/page.tsx
+++ b/apps/web/app/activities/trends/page.tsx
@@ -2,28 +2,13 @@ import { redirect } from 'next/navigation';
 
 import { ActivityTrendsChart } from '../../../components/activity-trends-chart';
 import { PageHeader } from '../../../components/page-header';
-import { Alert, AlertDescription, AlertTitle } from '../../../components/ui/alert';
 import { getServerAuthSession } from '../../../lib/auth';
 import { env } from '../../../lib/env';
-import type { PaginatedActivities } from '../../../types/activity';
-
-async function getActivities(token?: string): Promise<PaginatedActivities> {
-  const headers: HeadersInit | undefined = token ? { Authorization: `Bearer ${token}` } : undefined;
-  const response = await fetch(`${env.internalApiUrl}/activities?page=1&pageSize=200`, {
-    cache: 'no-store',
-    headers,
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to load activities');
-  }
-
-  return (await response.json()) as PaginatedActivities;
-}
 
 interface ActivityTrendsPageProps {
   searchParams?: {
     metric?: string | string[];
+    bucket?: string | string[];
   };
 }
 
@@ -36,33 +21,18 @@ export default async function ActivityTrendsPage({
     redirect('/signin');
   }
 
-  try {
-    const { data: activities } = await getActivities(session?.accessToken);
-    const metricParam = searchParams?.metric;
-    const initialMetricId = typeof metricParam === 'string' ? metricParam : undefined;
+  const metricParam = searchParams?.metric;
+  const bucketParam = searchParams?.bucket;
+  const initialMetricId = typeof metricParam === 'string' ? metricParam : undefined;
+  const initialBucket = typeof bucketParam === 'string' ? bucketParam : undefined;
 
-    return (
-      <div className="space-y-10">
-        <PageHeader
-          title="Activity trends"
-          description="Explore how your ride durations and computed metrics evolve across every activity you upload."
-        />
-        <ActivityTrendsChart activities={activities} initialMetricId={initialMetricId} />
-      </div>
-    );
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error while fetching trends.';
-    return (
-      <div className="space-y-10">
-        <PageHeader
-          title="Activity trends"
-          description="Explore how your ride durations and computed metrics evolve across every activity you upload."
-        />
-        <Alert variant="destructive">
-          <AlertTitle>Unable to load activity trends</AlertTitle>
-          <AlertDescription>{message}</AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
+  return (
+    <div className="space-y-10">
+      <PageHeader
+        title="Activity trends"
+        description="Explore how your ride durations and computed metrics evolve across every activity you upload."
+      />
+      <ActivityTrendsChart initialMetricId={initialMetricId} initialBucket={initialBucket} />
+    </div>
+  );
 }

--- a/apps/web/components/activity-trends-chart.tsx
+++ b/apps/web/components/activity-trends-chart.tsx
@@ -1,388 +1,1038 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
+  Area,
+  Bar,
+  Brush,
   CartesianGrid,
+  ComposedChart,
+  Legend,
   Line,
-  LineChart,
   ResponsiveContainer,
-  Tooltip,
+  Tooltip as RechartsTooltip,
   XAxis,
   YAxis,
 } from 'recharts';
+import { Download, LineChart as LineChartIcon, RefreshCcw } from 'lucide-react';
 
-import type { ActivitySummary } from '../types/activity';
+import { Button } from './ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Skeleton } from './ui/skeleton';
+import { Badge } from './ui/badge';
+import { Alert, AlertDescription, AlertTitle } from './ui/alert';
+import { cn } from '../lib/utils';
+
+interface TrendPoint {
+  bucket: string;
+  value: number | null;
+  n: number;
+}
+
+interface TrendResponse {
+  metric: string;
+  bucket: string;
+  timezone: string;
+  points: TrendPoint[];
+}
 
 interface ActivityTrendsChartProps {
-  activities: ActivitySummary[];
   initialMetricId?: string;
+  initialBucket?: string;
 }
 
-interface SeriesPoint {
-  activityId: string;
-  timestamp: number;
-  value: number;
-  activityLabel: string;
-}
+type MetricKey = 'avg-power' | 'avg-hr' | 'kilojoules' | 'tss' | 'durable-tss' | 'duration-hours';
+type BucketKey = 'day' | 'week' | 'month';
 
-interface MetricSeries {
-  id: string;
+interface MetricOption {
+  id: MetricKey;
   label: string;
-  unit?: string;
-  points: SeriesPoint[];
+  description: string;
+  unit: string;
 }
 
-function humanize(text: string) {
-  return text
-    .replace(/[_-]+/g, ' ')
-    .split(' ')
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+interface BucketOption {
+  id: BucketKey;
+  label: string;
+  description: string;
 }
 
-function guessUnit(field: string) {
-  const lower = field.toLowerCase();
-  if (lower.includes('w_per_hr')) {
-    return 'W/HR';
-  }
-  if (lower.includes('watts') || lower.includes('power')) {
-    return 'W';
-  }
-  if (lower.includes('hr') || lower.includes('heart')) {
-    return 'bpm';
-  }
-  if (lower.includes('cadence') || lower.includes('rpm')) {
-    return 'rpm';
-  }
-  if (lower.includes('speed')) {
-    return 'm/s';
-  }
-  if (lower.includes('temp')) {
-    return '°C';
-  }
-  if (lower.includes('seconds') || lower.includes('duration')) {
-    return 's';
-  }
-  return undefined;
+interface TrendSeriesPoint {
+  date: Date;
+  value: number | null;
+  n: number;
+  label: string;
 }
 
-export function ActivityTrendsChart({ activities, initialMetricId }: ActivityTrendsChartProps) {
-  const dateFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat('en', {
-        month: 'short',
-        day: 'numeric',
-      }),
-    [],
-  );
-  const fullDateFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat('en', {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      }),
-    [],
-  );
+interface TrendSeries {
+  metric: MetricKey;
+  bucket: BucketKey;
+  timezone: string;
+  points: TrendSeriesPoint[];
+}
 
-  const metricSeries = useMemo<MetricSeries[]>(() => {
-    if (activities.length === 0) {
-      return [];
+interface MovingAverageSeries {
+  key: string;
+  label: string;
+  color: string;
+  data: Array<{ date: Date; value: number | null }>;
+}
+
+interface QuantileBandPoint {
+  date: Date;
+  lower: number | null;
+  upper: number | null;
+}
+
+const METRIC_OPTIONS: MetricOption[] = [
+  {
+    id: 'avg-power',
+    label: 'Average power',
+    description: 'Mean ride power weighted by sample counts.',
+    unit: 'W',
+  },
+  {
+    id: 'avg-hr',
+    label: 'Average heart rate',
+    description: 'Mean ride heart rate using valid HR samples.',
+    unit: 'bpm',
+  },
+  {
+    id: 'kilojoules',
+    label: 'Total kilojoules',
+    description: 'Daily energy expenditure across all rides.',
+    unit: 'kJ',
+  },
+  {
+    id: 'duration-hours',
+    label: 'Ride hours',
+    description: 'Cumulative moving time converted to hours.',
+    unit: 'h',
+  },
+  {
+    id: 'tss',
+    label: 'Training Stress Score',
+    description: 'Approximate TSS using normalized load versus FTP.',
+    unit: 'TSS',
+  },
+  {
+    id: 'durable-tss',
+    label: 'Durable TSS',
+    description: 'Late-ride TSS calculated after the 1000 kJ mark.',
+    unit: 'TSS',
+  },
+];
+
+const BUCKET_OPTIONS: BucketOption[] = [
+  { id: 'day', label: 'Daily', description: 'Individual activity days with fine detail.' },
+  { id: 'week', label: 'Weekly', description: 'Week-over-week progression across blocks.' },
+  { id: 'month', label: 'Monthly', description: 'Long-term training phase trends.' },
+];
+
+const SPARKLINE_METRICS: MetricKey[] = [
+  'avg-power',
+  'avg-hr',
+  'kilojoules',
+  'duration-hours',
+  'tss',
+  'durable-tss',
+];
+
+const globalTrendCache = new Map<string, { data: TrendSeries; timestamp: number }>();
+const CACHE_TTL_MS = 1000 * 60 * 5;
+const FETCH_DEBOUNCE_MS = 250;
+
+function toCacheKey(metric: MetricKey, bucket: BucketKey, tz: string) {
+  return `${metric}:${bucket}:${tz}`;
+}
+
+function resolveTimeZone(): string {
+  if (typeof window === 'undefined') {
+    return 'UTC';
+  }
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch (error) {
+    return 'UTC';
+  }
+}
+
+function normalizeSeries(response: TrendResponse): TrendSeries {
+  return {
+    metric: response.metric as MetricKey,
+    bucket: response.bucket as BucketKey,
+    timezone: response.timezone,
+    points: [...response.points]
+      .map((point) => ({
+        date: new Date(point.bucket),
+        value: typeof point.value === 'number' && Number.isFinite(point.value) ? point.value : null,
+        n: point.n,
+        label: new Date(point.bucket).toLocaleString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        }),
+      }))
+      .sort((a, b) => a.date.getTime() - b.date.getTime()),
+  } satisfies TrendSeries;
+}
+
+async function fetchTrendSeries(
+  metric: MetricKey,
+  bucket: BucketKey,
+  tz: string,
+  signal?: AbortSignal,
+): Promise<TrendSeries> {
+  const params = new URLSearchParams({ metric, bucket, tz });
+  const response = await fetch(`/api/trends?${params.toString()}`, { signal });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Failed to load trend data.');
+  }
+  const payload = (await response.json()) as TrendResponse;
+  return normalizeSeries(payload);
+}
+
+interface UseTrendSeriesState {
+  data: TrendSeries | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+function useTrendSeries(metric: MetricKey, bucket: BucketKey, tz: string): UseTrendSeriesState {
+  const [state, setState] = useState<UseTrendSeriesState>({ data: null, isLoading: true, error: null });
+  const debounceRef = useRef<number | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const key = toCacheKey(metric, bucket, tz);
+    const cached = globalTrendCache.get(key);
+    const now = Date.now();
+    if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+      setState({ data: cached.data, isLoading: false, error: null });
+      return;
     }
 
-    const sortedActivities = [...activities].sort(
-      (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-    );
+    setState((previous) => ({ ...previous, isLoading: true, error: null }));
 
-    const map = new Map<string, MetricSeries>();
+    const controller = new AbortController();
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = controller;
 
-    map.set('activity.duration', {
-      id: 'activity.duration',
-      label: 'Ride duration (minutes)',
-      unit: 'min',
-      points: [],
-    });
-
-    for (const activity of sortedActivities) {
-      const timestamp = new Date(activity.startTime).getTime();
-      const activityLabel = new Date(activity.startTime).toLocaleString();
-      const durationMinutes = activity.durationSec / 60;
-      const durationSeries = map.get('activity.duration');
-      durationSeries?.points.push({
-        activityId: activity.id,
-        timestamp,
-        value: Number.isFinite(durationMinutes) ? Number(durationMinutes.toFixed(2)) : 0,
-        activityLabel,
-      });
-
-      for (const metric of activity.metrics) {
-        const summary = metric.summary as Record<string, unknown>;
-        for (const [fieldKey, fieldValue] of Object.entries(summary)) {
-          if (typeof fieldValue !== 'number' || !Number.isFinite(fieldValue)) {
-            continue;
-          }
-          const seriesId = `${metric.key}.${fieldKey}`;
-          const existing = map.get(seriesId);
-          const entry: MetricSeries = existing ?? {
-            id: seriesId,
-            label: `${humanize(metric.key)} – ${humanize(fieldKey)}`,
-            unit: guessUnit(fieldKey),
-            points: [],
-          };
-          entry.points.push({
-            activityId: activity.id,
-            timestamp,
-            value: Number(fieldValue.toFixed(3)),
-            activityLabel,
-          });
-          map.set(seriesId, entry);
-        }
-
-        if (metric.key === 'late-aerobic-efficiency') {
-          const validSampleCount = summary.valid_sample_count;
-          const totalSampleCount = summary.total_window_sample_count;
-          if (
-            typeof validSampleCount === 'number' &&
-            typeof totalSampleCount === 'number' &&
-            Number.isFinite(validSampleCount) &&
-            Number.isFinite(totalSampleCount) &&
-            totalSampleCount > 0
-          ) {
-            const coverageRatio = validSampleCount / totalSampleCount;
-            const seriesId = `${metric.key}.valid_sample_coverage_ratio`;
-            const existing = map.get(seriesId);
-            const entry: MetricSeries = existing ?? {
-              id: seriesId,
-              label: `${humanize(metric.key)} – Valid data coverage`,
-              unit: '%',
-              points: [],
-            };
-            entry.points.push({
-              activityId: activity.id,
-              timestamp,
-              value: Number((coverageRatio * 100).toFixed(1)),
-              activityLabel,
-            });
-            map.set(seriesId, entry);
-          }
-        }
-      }
+    if (debounceRef.current != null) {
+      window.clearTimeout(debounceRef.current);
     }
 
-    const series = Array.from(map.values()).map((entry) => ({
-      ...entry,
-      points: entry.points.sort((a, b) => a.timestamp - b.timestamp),
-    }));
+    debounceRef.current = window.setTimeout(async () => {
+      try {
+        const data = await fetchTrendSeries(metric, bucket, tz, controller.signal);
+        globalTrendCache.set(key, { data, timestamp: Date.now() });
+        setState({ data, isLoading: false, error: null });
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+          return;
+        }
+        setState({ data: null, isLoading: false, error: error as Error });
+      }
+    }, FETCH_DEBOUNCE_MS);
 
-    series.sort((a, b) => {
-      if (a.id === 'activity.duration') {
-        return -1;
+    return () => {
+      if (debounceRef.current != null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
       }
-      if (b.id === 'activity.duration') {
-        return 1;
-      }
-      return a.label.localeCompare(b.label);
+      controller.abort();
+    };
+  }, [metric, bucket, tz]);
+
+  return state;
+}
+
+function computeWindowSize(bucket: BucketKey, days: number) {
+  const bucketDays: Record<BucketKey, number> = { day: 1, week: 7, month: 30 };
+  const ratio = Math.max(1, Math.round(days / bucketDays[bucket]));
+  return ratio;
+}
+
+function computeMovingAverage(
+  points: TrendSeriesPoint[],
+  windowSize: number,
+): Array<{ date: Date; value: number | null }> {
+  if (windowSize <= 1) {
+    return points.map((point) => ({ date: point.date, value: point.value }));
+  }
+
+  const averages: Array<{ date: Date; value: number | null }> = [];
+  const window: number[] = [];
+
+  for (let index = 0; index < points.length; index += 1) {
+    const value = points[index]?.value ?? null;
+    if (value != null) {
+      window.push(value);
+    }
+    if (window.length > windowSize) {
+      window.shift();
+    }
+
+    if (window.length === windowSize) {
+      const sum = window.reduce((total, current) => total + current, 0);
+      averages.push({ date: points[index]!.date, value: Number((sum / window.length).toFixed(2)) });
+    } else {
+      averages.push({ date: points[index]!.date, value: null });
+    }
+  }
+
+  return averages;
+}
+
+function computeRollingQuantiles(
+  points: TrendSeriesPoint[],
+  windowSize: number,
+): QuantileBandPoint[] {
+  if (points.length === 0) {
+    return [];
+  }
+
+  const band: QuantileBandPoint[] = [];
+  const window: number[] = [];
+
+  for (let index = 0; index < points.length; index += 1) {
+    const value = points[index]?.value ?? null;
+    if (value != null) {
+      window.push(value);
+    }
+    if (window.length > windowSize) {
+      window.shift();
+    }
+
+    if (window.length < 3) {
+      band.push({ date: points[index]!.date, lower: null, upper: null });
+      continue;
+    }
+
+    const sorted = [...window].sort((a, b) => a - b);
+    const lowerIndex = Math.floor((sorted.length - 1) * 0.25);
+    const upperIndex = Math.floor((sorted.length - 1) * 0.75);
+    band.push({
+      date: points[index]!.date,
+      lower: Number(sorted[lowerIndex]!.toFixed(2)),
+      upper: Number(sorted[upperIndex]!.toFixed(2)),
     });
+  }
 
-    return series;
-  }, [activities]);
+  return band;
+}
 
-  const metricOptions = metricSeries.map((series) => ({
-    id: series.id,
-    label: series.label,
-    unit: series.unit,
-    count: series.points.length,
+interface CompareSeriesResult {
+  current: TrendSeriesPoint[];
+  previous: TrendSeriesPoint[];
+}
+
+function computeCompareSeries(points: TrendSeriesPoint[], bucket: BucketKey): CompareSeriesResult {
+  if (points.length === 0) {
+    return { current: [], previous: [] };
+  }
+
+  const daysPerBucket: Record<BucketKey, number> = { day: 1, week: 7, month: 30 };
+  const now = points[points.length - 1]!.date;
+  const bucketMs = daysPerBucket[bucket] * 24 * 60 * 60 * 1000;
+  const windowMs = 8 * 7 * 24 * 60 * 60 * 1000; // 8 weeks
+  const currentStart = new Date(now.getTime() - windowMs + bucketMs);
+  const previousEnd = new Date(currentStart.getTime() - bucketMs);
+  const previousStart = new Date(previousEnd.getTime() - windowMs + bucketMs);
+
+  const current = points.filter((point) => point.date >= currentStart);
+  const previousRaw = points.filter((point) => point.date >= previousStart && point.date <= previousEnd);
+
+  const shiftedPrevious = previousRaw.map((point) => ({
+    ...point,
+    date: new Date(point.date.getTime() + windowMs),
   }));
 
-  const appliedInitialMetricRef = useRef<string | undefined>(undefined);
+  return { current, previous: shiftedPrevious };
+}
 
-  const [selectedMetricId, setSelectedMetricId] = useState<string | undefined>(() => {
-    if (initialMetricId && metricOptions.some((option) => option.id === initialMetricId)) {
-      appliedInitialMetricRef.current = initialMetricId;
-      return initialMetricId;
-    }
-    return metricOptions.at(0)?.id;
-  });
-
-  useEffect(() => {
-    if (!initialMetricId) {
-      appliedInitialMetricRef.current = undefined;
-      return;
-    }
-    if (appliedInitialMetricRef.current === initialMetricId) {
-      return;
-    }
-    if (!metricOptions.some((option) => option.id === initialMetricId)) {
-      return;
-    }
-    appliedInitialMetricRef.current = initialMetricId;
-    setSelectedMetricId(initialMetricId);
-  }, [initialMetricId, metricOptions]);
-
-  useEffect(() => {
-    if (metricOptions.length === 0) {
-      if (selectedMetricId !== undefined) {
-        setSelectedMetricId(undefined);
-      }
-      return;
-    }
-
-    if (selectedMetricId && metricOptions.some((option) => option.id === selectedMetricId)) {
-      return;
-    }
-
-    const fallback =
-      (initialMetricId && metricOptions.some((option) => option.id === initialMetricId)
-        ? initialMetricId
-        : metricOptions[0]?.id) ?? undefined;
-
-    if (fallback !== selectedMetricId) {
-      setSelectedMetricId(fallback);
-    }
-  }, [metricOptions, selectedMetricId, initialMetricId]);
-
-  const selectedSeries = useMemo(() => {
-    if (metricOptions.length === 0) {
-      return undefined;
-    }
-    const found = metricSeries.find((series) => series.id === selectedMetricId);
-    return found ?? metricSeries[0];
-  }, [metricSeries, metricOptions.length, selectedMetricId]);
-
-  if (activities.length === 0) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base font-semibold">No activities yet</CardTitle>
-          <CardDescription>Upload a FIT file to unlock personalized trend charts.</CardDescription>
-        </CardHeader>
-      </Card>
-    );
-  }
-
-  if (!selectedSeries) {
-    return null;
-  }
-
-  const chartData = selectedSeries.points.map((point) => ({
-    date: point.timestamp,
+function buildChartData(points: TrendSeriesPoint[]) {
+  return points.map((point) => ({
+    date: point.date.getTime(),
     value: point.value,
-    activityId: point.activityId,
-    activityLabel: point.activityLabel,
+    n: point.n,
+    label: point.label,
   }));
+}
 
-  const latestHighlights = [...selectedSeries.points]
-    .filter((point) => Number.isFinite(point.value))
-    .slice(-3)
-    .reverse();
+function exportCsv(series: TrendSeries, averages: MovingAverageSeries[], filename: string) {
+  const headers = ['Bucket', 'Value', 'Sample count', ...averages.map((entry) => entry.label)];
+  const rows = series.points.map((point, index) => {
+    const averageValues = averages.map((entry) => entry.data[index]?.value ?? '');
+    const base = [point.date.toISOString(), point.value ?? '', point.n.toString(), ...averageValues];
+    return base.join(',');
+  });
+  const csv = [headers.join(','), ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `${filename}.csv`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function exportPng(container: HTMLDivElement | null, filename: string) {
+  if (!container) {
+    return;
+  }
+  const svg = container.querySelector('svg');
+  if (!svg) {
+    return;
+  }
+
+  const serializer = new XMLSerializer();
+  const svgString = serializer.serializeToString(svg);
+  const canvas = document.createElement('canvas');
+  const bounds = svg.getBoundingClientRect();
+  const scale = window.devicePixelRatio || 1;
+  canvas.width = bounds.width * scale;
+  canvas.height = bounds.height * scale;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return;
+  }
+  context.scale(scale, scale);
+
+  const image = new Image();
+  image.onload = () => {
+    context.clearRect(0, 0, bounds.width, bounds.height);
+    context.drawImage(image, 0, 0, bounds.width, bounds.height);
+    const url = canvas.toDataURL('image/png');
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${filename}.png`;
+    anchor.click();
+  };
+  const encoded = window.btoa(unescape(encodeURIComponent(svgString)));
+  image.src = `data:image/svg+xml;base64,${encoded}`;
+}
+
+interface SparklineData {
+  metric: MetricKey;
+  series: TrendSeries | null;
+}
+
+function SparklineGrid({
+  bucket,
+  timezone,
+  activeMetric,
+  onSelect,
+}: {
+  bucket: BucketKey;
+  timezone: string;
+  activeMetric: MetricKey;
+  onSelect: (metric: MetricKey) => void;
+}) {
+  const [data, setData] = useState<Record<MetricKey, TrendSeries | null>>({
+    'avg-power': null,
+    'avg-hr': null,
+    kilojoules: null,
+    'duration-hours': null,
+    tss: null,
+    'durable-tss': null,
+  });
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setIsLoading(true);
+    Promise.all(
+      SPARKLINE_METRICS.map(async (metric) => {
+        const key = toCacheKey(metric, bucket, timezone);
+        const cached = globalTrendCache.get(key);
+        if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+          return { metric, series: cached.data } satisfies SparklineData;
+        }
+        try {
+          const series = await fetchTrendSeries(metric, bucket, timezone);
+          globalTrendCache.set(key, { data: series, timestamp: Date.now() });
+          return { metric, series } satisfies SparklineData;
+        } catch (error) {
+          return { metric, series: null } satisfies SparklineData;
+        }
+      }),
+    ).then((entries) => {
+      if (!mounted) {
+        return;
+      }
+      const map: Record<MetricKey, TrendSeries | null> = {
+        'avg-power': null,
+        'avg-hr': null,
+        kilojoules: null,
+        'duration-hours': null,
+        tss: null,
+        'durable-tss': null,
+      };
+      for (const entry of entries) {
+        map[entry.metric] = entry.series;
+      }
+      setData(map);
+      setIsLoading(false);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [bucket, timezone]);
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="space-y-1">
-          <h2 className="text-2xl font-semibold text-foreground">Activity trends</h2>
-          <p className="text-sm text-muted-foreground">
-            Visualize how your ride duration and computed metrics evolve with every upload.
-          </p>
-        </div>
-        {metricOptions.length > 0 ? (
-          <div className="flex items-center gap-2">
-            <label htmlFor="metric-select" className="text-sm font-medium text-foreground">
-              Metric
-            </label>
-            <select
-              id="metric-select"
-              className="flex h-9 items-center rounded-md border border-input bg-background px-3 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-              value={selectedSeries.id}
-              onChange={(event) => setSelectedMetricId(event.target.value)}
-            >
-              {metricOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.label} ({option.count})
-                </option>
-              ))}
-            </select>
+    <div className="grid gap-3 md:grid-cols-3">
+      {SPARKLINE_METRICS.map((metric) => {
+        const option = METRIC_OPTIONS.find((entry) => entry.id === metric)!;
+        const series = data[metric];
+        const chartData = series ? buildChartData(series.points).slice(-24) : [];
+        return (
+          <button
+            type="button"
+            key={metric}
+            onClick={() => onSelect(metric)}
+            className={cn(
+              'group flex flex-col rounded-xl border border-border bg-card/70 p-4 text-left transition hover:-translate-y-0.5 hover:border-primary hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              activeMetric === metric && 'border-primary shadow-md',
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold text-foreground">{option.label}</span>
+              {activeMetric === metric ? (
+                <Badge variant="secondary">Active</Badge>
+              ) : null}
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">{option.description}</p>
+            <div className="mt-3 h-16 w-full">
+              {isLoading && !series ? (
+                <Skeleton className="h-full w-full" />
+              ) : series && chartData.length > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={chartData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--muted))" vertical={false} />
+                    <Line
+                      type="monotone"
+                      dataKey="value"
+                      stroke="hsl(var(--primary))"
+                      strokeWidth={1.5}
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex h-full items-center justify-center rounded bg-muted text-xs text-muted-foreground">
+                  No data
+                </div>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">No rides found</CardTitle>
+        <CardDescription>
+          Upload a FIT file to populate your training history and unlock trend analytics.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button asChild>
+          <a href="/upload">Upload a FIT</a>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>Unable to load trends</AlertTitle>
+      <AlertDescription className="flex flex-col gap-3 text-sm">
+        <span>{message}</span>
+        <Button variant="outline" size="sm" className="self-start" asChild>
+          <a href="/activities">Change filter</a>
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function ActivityTrendsChart({ initialMetricId, initialBucket }: ActivityTrendsChartProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tz = resolveTimeZone();
+
+  const defaultMetric = initialMetricId && METRIC_OPTIONS.some((option) => option.id === initialMetricId)
+    ? (initialMetricId as MetricKey)
+    : 'avg-power';
+  const defaultBucket = initialBucket && BUCKET_OPTIONS.some((option) => option.id === initialBucket)
+    ? (initialBucket as BucketKey)
+    : 'day';
+
+  const [metric, setMetric] = useState<MetricKey>(defaultMetric);
+  const [bucket, setBucket] = useState<BucketKey>(defaultBucket);
+  const [showSevenDayAverage, setShowSevenDayAverage] = useState(true);
+  const [showTwentyEightDayAverage, setShowTwentyEightDayAverage] = useState(false);
+  const [compareMode, setCompareMode] = useState(false);
+  const [showQuantileBand, setShowQuantileBand] = useState(true);
+  const [activeTooltipIndex, setActiveTooltipIndex] = useState<number | null>(null);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('metric', metric);
+    params.set('bucket', bucket);
+    router.replace(`?${params.toString()}`);
+  }, [router, searchParams, metric, bucket]);
+
+  const { data: series, isLoading, error } = useTrendSeries(metric, bucket, tz);
+  const contextMetric = metric === 'kilojoules' ? metric : 'kilojoules';
+  const { data: contextSeries } = useTrendSeries(contextMetric, bucket, tz);
+
+  const movingAverages = useMemo(() => {
+    if (!series) {
+      return [];
+    }
+    const windowSeven = computeWindowSize(series.bucket, 7);
+    const windowTwentyEight = computeWindowSize(series.bucket, 28);
+    const averages: MovingAverageSeries[] = [];
+    if (showSevenDayAverage) {
+      averages.push({
+        key: 'ma-7',
+        label: '7-day average',
+        color: 'hsl(var(--primary))',
+        data: computeMovingAverage(series.points, windowSeven),
+      });
+    }
+    if (showTwentyEightDayAverage) {
+      averages.push({
+        key: 'ma-28',
+        label: '28-day average',
+        color: 'hsl(var(--muted-foreground))',
+        data: computeMovingAverage(series.points, windowTwentyEight),
+      });
+    }
+    return averages;
+  }, [series, showSevenDayAverage, showTwentyEightDayAverage]);
+
+  const quantileBand = useMemo(() => {
+    if (!series || !showQuantileBand) {
+      return [];
+    }
+    const window = computeWindowSize(series.bucket, 21);
+    return computeRollingQuantiles(series.points, window);
+  }, [series, showQuantileBand]);
+
+  const compareSeries = useMemo(() => {
+    if (!series || !compareMode) {
+      return { current: [], previous: [] };
+    }
+    return computeCompareSeries(series.points, series.bucket);
+  }, [series, compareMode]);
+
+  const chartData = useMemo(() => (series ? buildChartData(series.points) : []), [series]);
+  const quantileData = useMemo(
+    () =>
+      quantileBand.map((entry) => ({
+        date: entry.date.getTime(),
+        lower: entry.lower,
+        band:
+          entry.upper != null && entry.lower != null
+            ? Number((entry.upper - entry.lower).toFixed(2))
+            : null,
+      })),
+    [quantileBand],
+  );
+
+  const movingAverageData = useMemo(() =>
+    movingAverages.map((average) =>
+      average.data.map((entry) => ({ date: entry.date.getTime(), value: entry.value })),
+    ),
+  [movingAverages]);
+
+  const compareData = useMemo(() => ({
+    current: compareSeries.current.map((entry) => ({
+      date: entry.date.getTime(),
+      value: entry.value,
+    })),
+    previous: compareSeries.previous.map((entry) => ({
+      date: entry.date.getTime(),
+      value: entry.value,
+    })),
+  }), [compareSeries]);
+
+  const contextData = useMemo(() => {
+    if (!contextSeries) {
+      return [];
+    }
+    return buildChartData(contextSeries.points).map((entry) => ({
+      date: entry.date,
+      contextValue: entry.value,
+    }));
+  }, [contextSeries]);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!chartData.length) {
+        return;
+      }
+      if (event.key === 'ArrowRight') {
+        setActiveTooltipIndex((index) => {
+          if (index == null) {
+            return 0;
+          }
+          return Math.min(index + 1, chartData.length - 1);
+        });
+      } else if (event.key === 'ArrowLeft') {
+        setActiveTooltipIndex((index) => {
+          if (index == null) {
+            return chartData.length - 1;
+          }
+          return Math.max(index - 1, 0);
+        });
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown as any);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown as any);
+    };
+  }, [chartData.length]);
+
+  useEffect(() => {
+    setActiveTooltipIndex(null);
+  }, [metric, bucket]);
+
+  const latestPoint = series?.points.at(-1);
+
+  const metricOption = METRIC_OPTIONS.find((entry) => entry.id === metric)!;
+
+  const defaultBrushStartIndex = useMemo(() => {
+    if (!chartData.length) {
+      return 0;
+    }
+    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+    const latestTime = chartData[chartData.length - 1]!.date;
+    const target = latestTime - ninetyDaysMs;
+    const index = chartData.findIndex((entry) => entry.date >= target);
+    return index >= 0 ? index : 0;
+  }, [chartData]);
+
+  const handleExportCsv = useCallback(() => {
+    if (!series) {
+      return;
+    }
+    const filename = `${series.metric}-${series.bucket}-trend`;
+    exportCsv(series, movingAverages, filename);
+  }, [series, movingAverages]);
+
+  const handleExportPng = useCallback(() => {
+    if (!series) {
+      return;
+    }
+    const filename = `${series.metric}-${series.bucket}-trend`;
+    exportPng(containerRef.current, filename);
+  }, [series]);
+
+  if (error) {
+    return <ErrorState message={error.message} />;
+  }
+
+  if (!isLoading && (!series || series.points.length === 0)) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 rounded-2xl border border-border bg-card/70 p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <LineChartIcon className="h-4 w-4" />
+              <span>Training signal</span>
+            </div>
+            <h2 className="text-2xl font-semibold text-foreground">Activity trends</h2>
+            <p className="text-sm text-muted-foreground">
+              Compare rolling volume, intensity, and efficiency to understand how your training load evolves.
+            </p>
           </div>
-        ) : null}
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 shadow-sm">
+              <span className="text-xs font-medium text-muted-foreground">Metric</span>
+              <select
+                className="bg-transparent text-sm font-medium text-foreground focus:outline-none"
+                value={metric}
+                onChange={(event) => setMetric(event.target.value as MetricKey)}
+              >
+                {METRIC_OPTIONS.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 shadow-sm">
+              <span className="text-xs font-medium text-muted-foreground">Bucket</span>
+              <select
+                className="bg-transparent text-sm font-medium text-foreground focus:outline-none"
+                value={bucket}
+                onChange={(event) => setBucket(event.target.value as BucketKey)}
+              >
+                {BUCKET_OPTIONS.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 shadow-sm">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="compare-toggle">
+                Compare
+              </label>
+              <input
+                id="compare-toggle"
+                type="checkbox"
+                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                checked={compareMode}
+                onChange={(event) => setCompareMode(event.target.checked)}
+              />
+            </div>
+            <div className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 shadow-sm">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="quantile-toggle">
+                Variability band
+              </label>
+              <input
+                id="quantile-toggle"
+                type="checkbox"
+                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                checked={showQuantileBand}
+                onChange={(event) => setShowQuantileBand(event.target.checked)}
+              />
+            </div>
+          </div>
+        </div>
+        <SparklineGrid bucket={bucket} timezone={tz} activeMetric={metric} onSelect={setMetric} />
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base font-semibold">{selectedSeries.label}</CardTitle>
-          <CardDescription>
-            {selectedSeries.points.length} activity{selectedSeries.points.length === 1 ? '' : 'ies'} tracked
-            {selectedSeries.unit ? ` · ${selectedSeries.unit}` : ''}.
-          </CardDescription>
+      <Card ref={containerRef} className="overflow-hidden">
+        <CardHeader className="gap-4 md:flex md:flex-row md:items-start md:justify-between">
+          <div>
+            <CardTitle className="text-base font-semibold">{metricOption.label}</CardTitle>
+            <CardDescription>{metricOption.description}</CardDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" size="sm" onClick={handleExportCsv} className="gap-2">
+              <Download className="h-4 w-4" /> CSV
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleExportPng} className="gap-2">
+              <Download className="h-4 w-4" /> PNG
+            </Button>
+            <div className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 shadow-sm">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="ma-7-toggle">
+                7d avg
+              </label>
+              <input
+                id="ma-7-toggle"
+                type="checkbox"
+                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                checked={showSevenDayAverage}
+                onChange={(event) => setShowSevenDayAverage(event.target.checked)}
+              />
+            </div>
+            <div className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 shadow-sm">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="ma-28-toggle">
+                28d avg
+              </label>
+              <input
+                id="ma-28-toggle"
+                type="checkbox"
+                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                checked={showTwentyEightDayAverage}
+                onChange={(event) => setShowTwentyEightDayAverage(event.target.checked)}
+              />
+            </div>
+          </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="h-[360px] w-full">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={chartData} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="4 4" stroke="hsl(var(--muted))" />
-                <XAxis
-                  dataKey="date"
-                  type="number"
-                  tickFormatter={(value) => dateFormatter.format(new Date(value))}
-                  tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
-                  axisLine={{ stroke: 'hsl(var(--border))' }}
-                  tickLine={{ stroke: 'hsl(var(--border))' }}
-                  domain={['auto', 'auto']}
-                />
-                <YAxis
-                  tickFormatter={(value) => value.toString()}
-                  tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
-                  axisLine={{ stroke: 'hsl(var(--border))' }}
-                  tickLine={{ stroke: 'hsl(var(--border))' }}
-                  width={60}
-                />
-                <Tooltip
-                  contentStyle={{ borderRadius: '0.75rem', borderColor: 'hsl(var(--border))' }}
-                  labelFormatter={(value) => fullDateFormatter.format(new Date(value))}
-                  formatter={(value: number) => {
-                    const formattedValue = Number.isFinite(value)
-                      ? value.toLocaleString(undefined, {
-                          maximumFractionDigits: 2,
-                        })
-                      : '—';
-                    const unit = selectedSeries.unit ? ` ${selectedSeries.unit}` : '';
-                    return [`${formattedValue}${unit}`, selectedSeries.label];
+          <div className="h-[420px] w-full">
+            {isLoading && !series ? (
+              <Skeleton className="h-full w-full" />
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart
+                  data={chartData}
+                  margin={{ top: 20, right: 24, left: 0, bottom: 0 }}
+                  onMouseMove={(state) => {
+                    if (typeof state.activeTooltipIndex === 'number') {
+                      setActiveTooltipIndex(state.activeTooltipIndex);
+                    }
                   }}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="value"
-                  stroke="hsl(var(--primary))"
-                  strokeWidth={2}
-                  dot={false}
-                  activeDot={{ r: 5 }}
-                />
-              </LineChart>
-            </ResponsiveContainer>
+                  onMouseLeave={() => setActiveTooltipIndex(null)}
+                  activeTooltipIndex={activeTooltipIndex ?? undefined}
+                >
+                  <CartesianGrid strokeDasharray="4 4" stroke="hsl(var(--muted))" />
+                  <XAxis
+                    dataKey="date"
+                    type="number"
+                    tickFormatter={(value) => new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                    tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
+                    domain={['auto', 'auto']}
+                  />
+                  <YAxis
+                    yAxisId="primary"
+                    tickFormatter={(value) => value.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+                    tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
+                    axisLine={{ stroke: 'hsl(var(--border))' }}
+                    tickLine={{ stroke: 'hsl(var(--border))' }}
+                    width={72}
+                  />
+                  <YAxis
+                    yAxisId="context"
+                    orientation="right"
+                    hide
+                    tickFormatter={(value) => value.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  />
+                  <RechartsTooltip
+                    labelFormatter={(value) => new Date(value).toLocaleString()}
+                    contentStyle={{ borderRadius: 12, borderColor: 'hsl(var(--border))' }}
+                    formatter={(value: number, name) => {
+                      if (name === 'contextValue') {
+                        return [`${value.toLocaleString(undefined, { maximumFractionDigits: 0 })} kJ`, 'Energy'];
+                      }
+                      const formatted = Number.isFinite(value)
+                        ? value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+                        : '—';
+                      return [metricOption.unit ? `${formatted} ${metricOption.unit}` : formatted, metricOption.label];
+                    }}
+                  />
+                  <Legend />
+                  {showQuantileBand && quantileData.length > 0 ? (
+                    <>
+                      <Area
+                        yAxisId="primary"
+                        type="monotone"
+                        data={quantileData}
+                        dataKey="lower"
+                        stroke="none"
+                        fill="transparent"
+                        stackId="quantile"
+                        isAnimationActive={false}
+                      />
+                      <Area
+                        yAxisId="primary"
+                        type="monotone"
+                        data={quantileData}
+                        dataKey="band"
+                        stroke="none"
+                        fill="url(#quantileGradient)"
+                        stackId="quantile"
+                        isAnimationActive={false}
+                        name="P25-P75"
+                      />
+                    </>
+                  ) : null}
+                  <Bar
+                    data={contextData}
+                    dataKey="contextValue"
+                    yAxisId="context"
+                    name="Energy"
+                    fill="hsl(var(--muted))"
+                    barSize={8}
+                    opacity={0.4}
+                  />
+                  <Line
+                    yAxisId="primary"
+                    type="monotone"
+                    dataKey="value"
+                    stroke="hsl(var(--primary))"
+                    strokeWidth={2.5}
+                    dot={false}
+                    isAnimationActive={false}
+                    name={metricOption.label}
+                  />
+                  {movingAverageData.map((data, index) => (
+                    <Line
+                      key={movingAverages[index]!.key}
+                      yAxisId="primary"
+                      type="monotone"
+                      data={data}
+                      dataKey="value"
+                      stroke={movingAverages[index]!.color}
+                      strokeWidth={1.5}
+                      strokeDasharray="6 6"
+                      dot={false}
+                      name={movingAverages[index]!.label}
+                    />
+                  ))}
+                  {compareMode ? (
+                    <Line
+                      yAxisId="primary"
+                      type="monotone"
+                      data={compareData.current}
+                      dataKey="value"
+                      stroke="hsl(var(--primary))"
+                      strokeWidth={3}
+                      dot={false}
+                      name="Last 8 weeks"
+                    />
+                  ) : null}
+                  {compareMode ? (
+                    <Line
+                      yAxisId="primary"
+                      type="monotone"
+                      data={compareData.previous}
+                      dataKey="value"
+                      stroke="hsl(var(--secondary))"
+                      strokeWidth={2}
+                      strokeDasharray="4 4"
+                      dot={false}
+                      name="Previous 8 weeks"
+                    />
+                  ) : null}
+                  <Brush
+                    travellerWidth={12}
+                    dataKey="date"
+                    startIndex={defaultBrushStartIndex}
+                    height={24}
+                    stroke="hsl(var(--primary))"
+                  />
+                  <defs>
+                    <linearGradient id="quantileGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity={0.12} />
+                      <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0.02} />
+                    </linearGradient>
+                  </defs>
+                </ComposedChart>
+              </ResponsiveContainer>
+            )}
           </div>
 
-          <div>
-            <h3 className="text-sm font-semibold text-foreground">Recent highlights</h3>
-            {latestHighlights.length > 0 ? (
-              <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
-                {latestHighlights.map((point) => (
-                  <li key={`${selectedSeries.id}-${point.activityId}`}>
-                    <span className="font-medium text-foreground">
-                      {fullDateFormatter.format(new Date(point.timestamp))}
-                    </span>
-                    : {point.value.toLocaleString(undefined, { maximumFractionDigits: 2 })}
-                    {selectedSeries.unit ? ` ${selectedSeries.unit}` : ''}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="mt-2 text-sm text-muted-foreground">
-                Once this metric has at least one value we&apos;ll showcase the most recent performances here.
+          <div className="grid gap-4 rounded-xl border border-border bg-muted/20 p-4 md:grid-cols-2">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Latest highlight</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {latestPoint
+                  ? `${latestPoint.label}: ${latestPoint.value?.toLocaleString(undefined, {
+                      maximumFractionDigits: 1,
+                    }) ?? '—'} ${metricOption.unit}`
+                  : 'Once new rides are processed, highlights will appear here.'}
               </p>
-            )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <RefreshCcw className="h-4 w-4" />
+              Updated automatically after each upload · Bucketed by {bucket} · {series?.timezone ?? tz}
+            </div>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add a `/api/trends` endpoint that aggregates ride metrics by day, week, or month and supports power, heart rate, kilojoule, TSS, durable TSS, and duration views
- register the new endpoint in the API router so authenticated users can query trend data
- rebuild the activity trends client to query the API, add metric & bucket selectors, moving averages, compare mode, quantile shading, sparklines, context bars, keyboardable tooltips, and export actions
- simplify the trends page to rely on the client component and URL-synced search params

## Testing
- pnpm --filter web lint
- pnpm --filter backend test

------
https://chatgpt.com/codex/tasks/task_e_68e52dfedc5c8330b12e1c624fbe96a7