### PR TITLE
Handle Asia/Saigon timezone alias

### DIFF
--- a/apps/backend/src/routes/trends.ts
+++ b/apps/backend/src/routes/trends.ts
@@ -39,16 +39,21 @@ interface TrendRow {
   n: bigint;
 }
 
+const POSTGRES_TIMEZONE_ALIASES: Record<string, string> = {
+  'Asia/Saigon': 'Asia/Ho_Chi_Minh',
+};
+
 function resolveTimezone(tz: string): string {
   if (!tz) {
     return 'UTC';
   }
 
+  const normalizedTz = POSTGRES_TIMEZONE_ALIASES[tz] ?? tz;
+
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    new Intl.DateTimeFormat('en-US', { timeZone: tz });
-    return tz;
-  } catch (error) {
+    new Intl.DateTimeFormat('en-US', { timeZone: normalizedTz });
+    return normalizedTz;
+  } catch (_error) {
     return 'UTC';
   }
 }


### PR DESCRIPTION
## Summary
- normalize the Asia/Saigon timezone to the Postgres-recognized Asia/Ho_Chi_Minh identifier
- keep timezone validation in place while falling back to UTC when the normalized zone is invalid

## Testing
- pnpm --filter backend lint *(fails: existing import-order violations in services that predate this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e670479d7083308327b6240463befb